### PR TITLE
fix(agent): make seahorse emergency compaction shrink live session history

### DIFF
--- a/pkg/agent/context_legacy.go
+++ b/pkg/agent/context_legacy.go
@@ -95,7 +95,14 @@ func (m *legacyContextManager) maybeSummarize(sessionKey string) {
 	}
 }
 
-// forceCompression aggressively reduces context when the limit is hit.
+// forceCompression is the legacy manager's emergency reducer. It delegates to
+// the shared forceCompressSessionHistory helper, which both the legacy and
+// seahorse managers use for emergency (proactive + retry) compaction.
+func (m *legacyContextManager) forceCompression(sessionKey string) {
+	forceCompressSessionHistory(m.al.registry.GetDefaultAgent(), sessionKey)
+}
+
+// forceCompressSessionHistory aggressively reduces context when the limit is hit.
 // It drops the oldest ~50% of Turns (a Turn is a complete user→LLM→response
 // cycle, as defined in #1316), so tool-call sequences are never split.
 //
@@ -107,8 +114,11 @@ func (m *legacyContextManager) maybeSummarize(sessionKey string) {
 // prompt is built dynamically by BuildMessages and is NOT stored here.
 // The compression note is recorded in the session summary so that
 // BuildMessages can include it in the next system prompt.
-func (m *legacyContextManager) forceCompression(sessionKey string) {
-	agent := m.al.registry.GetDefaultAgent()
+//
+// It writes the trimmed history back to the session store — the source of
+// truth the agent loop reads from on every (re-)build — so a re-read after
+// compaction sees the shrunk result.
+func forceCompressSessionHistory(agent *AgentInstance, sessionKey string) {
 	if agent == nil {
 		return
 	}

--- a/pkg/agent/context_seahorse.go
+++ b/pkg/agent/context_seahorse.go
@@ -19,6 +19,7 @@ import (
 type seahorseContextManager struct {
 	engine   *seahorse.Engine
 	sessions session.SessionStore // for startup bootstrap
+	al       *AgentLoop           // resolves the live session store for emergency compaction
 }
 
 // newSeahorseContextManager creates a seahorse-backed ContextManager.
@@ -46,6 +47,7 @@ func newSeahorseContextManager(_ json.RawMessage, al *AgentLoop) (ContextManager
 	mgr := &seahorseContextManager{
 		engine:   engine,
 		sessions: agent.Sessions,
+		al:       al,
 	}
 
 	// Register seahorse tools with the agent's tool registry
@@ -128,19 +130,34 @@ func (m *seahorseContextManager) Compact(ctx context.Context, req *CompactReques
 		return nil
 	}
 
-	// For retry (LLM overflow), use aggressive CompactUntilUnder to guarantee
-	// context shrinks below budget (spec lines ~1410).
-	if req.Reason == ContextCompressReasonRetry && req.Budget > 0 {
-		_, err := m.engine.CompactUntilUnder(ctx, req.SessionKey, req.Budget)
-		return err
+	// Emergency compaction (proactive budget check + LLM-overflow retry).
+	//
+	// The agent loop builds and re-reads its LLM request straight from
+	// agent.Sessions — it never calls Assemble — so the load-bearing action is
+	// shrinking agent.Sessions directly. Compacting only the seahorse engine
+	// would leave the re-read unchanged, so the retry would resend the same
+	// oversized history and overflow again. Mirror the legacy turn-dropping
+	// logic on the live session store.
+	if req.Reason == ContextCompressReasonProactive || req.Reason == ContextCompressReasonRetry {
+		forceCompressSessionHistory(m.al.registry.GetDefaultAgent(), req.SessionKey)
+		// Best-effort: keep the seahorse engine roughly in sync for its grep/
+		// expand tools. Non-load-bearing (the loop doesn't read it), so a
+		// failure here must not abort the shrink above.
+		if req.Budget > 0 {
+			if _, err := m.engine.CompactUntilUnder(ctx, req.SessionKey, req.Budget); err != nil {
+				logger.WarnCF("seahorse", "best-effort engine compaction failed",
+					map[string]any{"session": req.SessionKey, "error": err.Error()})
+			}
+		}
+		return nil
 	}
 
+	// Post-turn summarize: compress the seahorse engine store.
 	var budgetPtr *int
 	if req.Budget > 0 {
 		budgetPtr = &req.Budget
 	}
 	_, err := m.engine.Compact(ctx, req.SessionKey, seahorse.CompactInput{
-		Force:  req.Reason == ContextCompressReasonRetry,
 		Budget: budgetPtr,
 	})
 	return err

--- a/pkg/agent/context_seahorse_test.go
+++ b/pkg/agent/context_seahorse_test.go
@@ -3,10 +3,58 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
 	"github.com/cryptoquantumwave/khunquant/pkg/providers/protocoltypes"
 )
+
+// TestSeahorseContextManager_EmergencyCompactShrinksSessions verifies the fix
+// for the bug where seahorse's emergency Compact only touched its own SQLite
+// engine, leaving agent.Sessions (the store the loop actually re-reads) intact —
+// so the context-overflow retry kept resending the same oversized history.
+// After Compact with ContextCompressReasonRetry, agent.Sessions must be shorter.
+func TestSeahorseContextManager_EmergencyCompactShrinksSessions(t *testing.T) {
+	al, _, _, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+
+	agent := al.registry.GetDefaultAgent()
+	if agent == nil {
+		t.Fatalf("expected default agent, got nil")
+	}
+
+	mgrAny, err := newSeahorseContextManager(nil, al)
+	if err != nil {
+		t.Fatalf("construct seahorse manager: %v", err)
+	}
+	mgr := mgrAny.(*seahorseContextManager)
+
+	sessionKey := "seahorse-emergency-compact"
+	history := []providers.Message{
+		{Role: "user", Content: "message 1"},
+		{Role: "assistant", Content: "response 1"},
+		{Role: "user", Content: "message 2"},
+		{Role: "assistant", Content: "response 2"},
+		{Role: "user", Content: "message 3"},
+		{Role: "assistant", Content: "response 3"},
+	}
+	agent.Sessions.SetHistory(sessionKey, history)
+
+	if err := mgr.Compact(context.Background(), &CompactRequest{
+		SessionKey: sessionKey,
+		Reason:     ContextCompressReasonRetry,
+		Budget:     agent.ContextWindow,
+	}); err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+
+	newHistory := agent.Sessions.GetHistory(sessionKey)
+	if len(newHistory) >= len(history) {
+		t.Errorf("expected emergency compaction to shrink session history: %d -> %d",
+			len(history), len(newHistory))
+	}
+}
 
 func TestProviderToSeahorseMessage_Basic(t *testing.T) {
 	msg := protocoltypes.Message{


### PR DESCRIPTION
## Problem

A recurring cron job (e.g. a portfolio summary every 4h) eventually died with `Context window exceeded. Compressing history and retrying...` and produced no output.

Root cause: with the **seahorse** context manager (the shipped default), emergency `Compact()` — both the proactive budget check (`loop.go:1141`) and the LLM-overflow retry (`loop.go:1618`) — only compacted seahorse's own SQLite engine. But the agent loop builds and **re-reads its LLM request directly from `agent.Sessions`** (`loop.go:1117`, `1146`, `1623`); it never calls `Assemble`. So the compaction never touched the history being resent:

- Retry re-read the same un-shrunk history → resent the same oversized payload → 400 again → exhausted `maxRetries` → turn dropped with no output.
- The proactive check had the same gap, so the session grew unbounded until it overflowed.

The symptom itself proves it: if seahorse `Compact` worked on the live history, the proactive check would have kept the session under budget for days instead of letting it grow to a 400.

## Fix (narrow / low-risk)

- Extract legacy's proven turn-dropping logic into a shared package-level helper `forceCompressSessionHistory(agent, sessionKey)` — pure move, legacy behavior unchanged.
- seahorse's emergency path (proactive + retry) now calls that helper to shrink `agent.Sessions` directly — the store the loop actually re-reads — with a best-effort engine sync afterward (non-load-bearing; can't abort the real shrink).
- Add `al` to the seahorse manager so it resolves the live session store the same way legacy does.

## Scope / not in this PR

Found during investigation that seahorse's `Assemble` + `Ingest` read/sync path is **dead** — never wired into the loop (git-confirmed it never was). This PR fixes only the emergency-recovery path. Wiring `Assemble`/`Ingest` is a separate, higher-blast-radius change tracked separately.

## Testing

- New `TestSeahorseContextManager_EmergencyCompactShrinksSessions` asserts the real thing: after `Compact` with `ContextCompressReasonRetry`, `agent.Sessions.GetHistory` is actually shorter (would fail pre-fix).
- `go build ./...`, `go vet ./pkg/agent/`, and full `pkg/agent` suite pass; legacy compaction tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)