### PR TITLE
sync(upstream): port 10 beneficial fixes from picoclaw v0.2.9

### DIFF
--- a/docker/Dockerfile.heavy
+++ b/docker/Dockerfile.heavy
@@ -1,0 +1,67 @@
+# ============================================================
+# Stage 1: Build the khunquant binary
+# ============================================================
+FROM golang:1.26.3-alpine AS builder
+
+RUN apk add --no-cache git make
+
+WORKDIR /src
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build
+COPY . .
+RUN make build
+
+# ============================================================
+# Stage 2: Node.js runtime with Python + browser + MCP support
+# ============================================================
+FROM node:24-alpine3.23
+
+RUN apk add --no-cache \
+  ca-certificates \
+  curl \
+  git \
+  python3 \
+  py3-pip \
+  chromium \
+  jq
+
+# Install Playwright browsers for agent-browser
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+RUN npm install -g agent-browser && \
+    npx playwright install chromium && \
+    chmod -R o+rx $PLAYWRIGHT_BROWSERS_PATH
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+  ln -s /root/.local/bin/uv /usr/local/bin/uv && \
+  ln -s /root/.local/bin/uvx /usr/local/bin/uvx && \
+  uv --version
+
+# Health check (gateway health endpoint defaults to port 18790)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://localhost:18790/health || exit 1
+
+# Copy binary
+COPY --from=builder /src/build/khunquant /usr/local/bin/khunquant
+
+# Reuse existing node user (UID/GID 1000) — rename to khunquant
+RUN deluser node 2>/dev/null; delgroup node 2>/dev/null; \
+    addgroup -g 1000 khunquant 2>/dev/null; \
+    adduser -D -u 1000 -G khunquant -h /home/khunquant khunquant 2>/dev/null || true
+
+USER khunquant
+
+# Run onboard to create initial directories and config
+RUN /usr/local/bin/khunquant onboard
+
+# Copy default workspace
+COPY --chown=khunquant:khunquant workspace/ /home/khunquant/.khunquant/workspace/
+
+VOLUME /home/khunquant/.khunquant/workspace
+
+ENTRYPOINT ["khunquant"]
+CMD ["gateway"]

--- a/docs/adr-agent-core-convergence.md
+++ b/docs/adr-agent-core-convergence.md
@@ -72,8 +72,30 @@ Refactoring a core with no spec → use characterization tests as the safety net
   - Still seam-testable but deferred to broaden later: context-budget/summarization triggers and
     multi-agent delegate/spawn routing (both need more setup — a summarizing provider / a
     multi-agent registry — and are lower-churn than the core turn loop).
-- ▶ **Step 3 (spike):** on a branch, swap ONE subsystem to upstream's, re-green it; measure the
-  real per-subsystem cost before committing to the full rebase.
+- ✅ **Step 3 (spike — done, measured & discarded):** dropped upstream v0.2.9's *entire* `pkg/agent`
+  onto a throwaway branch (import paths rewritten), kept our seam characterization test, measured
+  the blast radius, then discarded. Findings (decision-grade):
+  1. **Caller blast radius is tiny:** only **3 packages** outside `pkg/agent` import it
+     (`cmd/khunquant/internal/agent`, `cmd/khunquant/internal/gateway`, `pkg/devmcp`). The core is
+     well-encapsulated — re-integration touches a narrow surface.
+  2. **Adopting upstream's agent is dependency-closure work, not logic-untangling:** the wholesale
+     overlay produced **12 compile errors, all "missing package/symbol"** — upstream sibling
+     packages our fork lacks (`pkg/audio`, `pkg/events`, `pkg/isolation`, `pkg/evolution`, + 2
+     `pkg/providers` symbols). **Zero** were semantic conflicts inside the agent logic. So the
+     rebase is "bring ~5 sibling packages + wire," which is far more tractable than feared.
+  3. **The seam methodology is validated:** 8 of our 9 characterization tests rely on public API
+     that survives the refactor **unchanged** — `NewAgentLoop` (even stays backward-compatible via
+     new variadic opts), `ProcessDirect` (identical), `RegisterTool`, `toolLimitResponse`. The
+     **one** drift: upstream removed the fork-specific `noHistory` param from
+     `ProcessDirectWithChannel`, so `CHAR-6 (NoHistoryIsolation)` is the single test needing a
+     conscious ADAPT (re-add `noHistory` as our delta, or adopt upstream's no-history mechanism).
+     This is exactly the kind of decision point the guard exists to surface.
+  - **Net:** the spike *lowered* the risk estimate. The agent rebase looks like a bounded
+    bring-the-deps + thin-reintegration effort (encapsulated, conflict-free logic), not a
+    multi-week untangle. Recommend: bring the ~5 sibling packages first, then the wholesale
+    `pkg/agent` adoption, re-greening this suite (adapting CHAR-6 consciously).
+- ▶ **Step 3b (next):** repeat the measurement against the **latest stable upstream** (not v0.2.9)
+  to confirm the dependency closure there before scheduling the rebase.
 - ▶ **Step 4:** full wholesale adoption + seam-based re-integration, suite as the gate, agent-core
   feature-freeze during the rebase, plus crypto end-to-end validation (a real paper-trade flow).
 - Meanwhile: keep hand-porting fix *logic* (network-retry etc.) to stop the bleeding — independent

--- a/docs/adr-agent-core-convergence.md
+++ b/docs/adr-agent-core-convergence.md
@@ -94,8 +94,36 @@ Refactoring a core with no spec → use characterization tests as the safety net
     bring-the-deps + thin-reintegration effort (encapsulated, conflict-free logic), not a
     multi-week untangle. Recommend: bring the ~5 sibling packages first, then the wholesale
     `pkg/agent` adoption, re-greening this suite (adapting CHAR-6 consciously).
-- ▶ **Step 3b (next):** repeat the measurement against the **latest stable upstream** (not v0.2.9)
-  to confirm the dependency closure there before scheduling the rebase.
+- ✅ **Step 3b (done):** sized the **real** target. After `git fetch upstream`, the latest stable
+  tag is **v0.3.0** (upstream/main is +283 from v0.2.9). Findings:
+  1. **The agent architecture has STABILIZED.** `pkg/agent` is essentially unchanged v0.2.9→v0.3.0
+     (only a new `turn_state_test.go`; no source/structural changes). The "moving target" risk is
+     resolved — v0.3.0 is a settled convergence point.
+  2. **Dependency closure is clean and small.** Upstream's v0.3.0 agent needs only 4 sibling
+     packages we lack; none pull further missing `pkg/*`. By *actual agent coupling*:
+     - **`pkg/events`** — 19 agent files / 45 symbols, core to the new architecture → **must bring**
+       (1174 LOC, pure stdlib, no external deps — easy).
+     - **`pkg/isolation`** — 2 files / 2 symbols (`Configure`, `Start`) → trivial: bring (949 LOC)
+       or a 2-func stub.
+     - **`pkg/audio`** — **0 agent files / 0 symbols at v0.3.0** → **skip** (avoids pulling
+       `pion/webrtc`+`pion/rtp`; keeps footprint).
+     - **`pkg/evolution`** — 1 agent file but 30 symbols (self-evolution) → **product decision**:
+       bring (5874 LOC, clean, no ext deps) or exclude that one feature file.
+  - **Revised estimate:** the mandatory dependency cost collapses to **one small clean package
+    (`pkg/events`)** + a trivial isolation shim. Audio drops out; evolution is opt-in. Combined
+    with the tiny caller blast radius (3 importers) and conflict-free agent logic, the convergence
+    is a **bounded, well-scoped project**, not a fork-threatening rewrite.
+
+## Recommended execution (updated by the spikes)
+
+Target **v0.3.0** (stable, settled architecture). On a branch:
+1. Bring `pkg/events` (clean) and decide isolation (bring/stub) + evolution (adopt/exclude) + skip audio.
+2. Overlay upstream v0.3.0 `pkg/agent`; rewrite import paths.
+3. Re-apply our deltas via extension seams (tools already via registry; trading observability via
+   `pkg/events`/hooks; re-add `noHistory` to `ProcessDirectWithChannel` as our documented delta).
+4. Re-green the characterization suite (consciously ADAPT CHAR-6 for the `noHistory` signature).
+5. Update the 3 caller packages (`cmd/.../agent`, `cmd/.../gateway`, `pkg/devmcp`) for any API drift.
+6. Crypto end-to-end validation (a real paper-trade flow) before merge.
 - ▶ **Step 4:** full wholesale adoption + seam-based re-integration, suite as the gate, agent-core
   feature-freeze during the rebase, plus crypto end-to-end validation (a real paper-trade flow).
 - Meanwhile: keep hand-porting fix *logic* (network-retry etc.) to stop the bleeding — independent

--- a/docs/adr-agent-core-convergence.md
+++ b/docs/adr-agent-core-convergence.md
@@ -1,0 +1,79 @@
+# ADR: Converge the agent core onto upstream to enable cheap long-term syncing
+
+**Status:** Accepted (strategy) · Step 1 implemented · remainder scheduled
+**Date:** 2026-06
+**Context source:** upstream sync of picoclaw v0.2.9 (see `upstream-sync-v0.2.9.md`)
+
+## Problem
+
+KhunQuant tracks upstream `sipeed/picoclaw` (proven: `pkg/seahorse` is byte-identical;
+multiple `sync/*` branches). But our `pkg/agent` core diverged from upstream's: upstream
+refactored the monolithic `loop.go` into a `pipeline_*` / `adapters` / `interfaces`
+architecture and added hooks + an event bus, while we kept the monolith and evolved it
+independently (~3770/592 lines of delta across non-test agent files). Result: a growing
+**fork-drift tax** — agent-core fixes increasingly land in files we don't have and must be
+hand-translated each release. We want future upstream syncs to stay cheap.
+
+## Decision
+
+Converge our agent core onto upstream's architecture so our `pkg/agent` delta trends toward
+**near-zero**, making future syncs ordinary cherry-picks. Two non-obvious principles govern
+how:
+
+1. **The goal is "minimize our core delta," not "mimic their layout."** Upstream built
+   hooks / event bus / `interfaces`+`adapters` precisely so downstream extensions don't fork
+   the core. Re-express our add-ons through those **extension seams** instead of re-patching
+   core files. Success metric: *lines of our delta remaining in `pkg/agent` core files*.
+   - Crypto tools already ride the tool registry → effectively zero core delta. Keep it that way.
+   - Trading-risk gating / observability / custom turn behavior → onto hooks/eventbus.
+   - Session/context tweaks → through interfaces/adapters where possible.
+
+2. **The recurring fix-tax is separable from architecture adoption.** Verified: blocked fixes
+   like network-retry are self-contained logic that drop into our existing LLM call-site
+   (`loop.go` `callLLM`/`Chat`) — they do *not* require the pipeline. So we hand-port fix
+   *logic* as needed regardless, and treat full architecture adoption as its own decision,
+   justified by wanting hooks/eventbus/turn-coord for KhunQuant's roadmap.
+
+## Method — characterization-test-guarded refactor (green → red → green)
+
+Refactoring a core with no spec → use characterization tests as the safety net, but:
+
+- **Test at the STABLE SEAM, not internals.** Assertions go through the public
+  `ProcessDirect` / message-bus API with provider/tool fakes (inbound → outbound, tool calls
+  + args, session/history state, system prompt). These survive the architecture swap and
+  *compile on both layouts* — tests bound to `runTurn`/`callLLM`/internal types would fail to
+  compile after the swap and are worse than nothing.
+- **Flow:** suite green on current core → adopt upstream's `pkg/agent` wholesale (red) →
+  re-integrate our deltas via extension seams → green.
+- **Re-integration is a triage, not a blind re-apply:** for each red, decide KEEP (genuine
+  fork behavior → re-apply via a seam), DROP (our parallel impl now provided by upstream), or
+  ADAPT (the assertion can't survive — change it consciously).
+
+### Convergence target & timing
+- Converge to the **latest stable upstream**, not v0.2.9 (upstream refactored the agent core
+  twice in our window; v0.2.9's layout is already superseded — converging there risks
+  re-paying soon).
+- Prefer timing the wholesale adoption to when upstream's agent architecture has settled.
+- Caveat: characterization can't capture everything (timing, concurrency, context-budget
+  math); expect a few "can't preserve" decisions.
+
+## Status / next steps
+
+- ✅ **Step 1 (done):** characterization suite at the seam — `pkg/agent/characterization_test.go`
+  (plain response, tool round-trip, session continuity, system prompt). Green on current core.
+  This is the permanent guard for every future sync.
+- ▶ **Step 2:** expand the suite to cover more must-preserve behaviors (context budgeting /
+  summarization triggers, steering/interrupt, paper-trading & leverage gating, multi-agent
+  delegate/spawn) — still at the seam.
+- ▶ **Step 3 (spike):** on a branch, swap ONE subsystem to upstream's, re-green it; measure the
+  real per-subsystem cost before committing to the full rebase.
+- ▶ **Step 4:** full wholesale adoption + seam-based re-integration, suite as the gate, agent-core
+  feature-freeze during the rebase, plus crypto end-to-end validation (a real paper-trade flow).
+- Meanwhile: keep hand-porting fix *logic* (network-retry etc.) to stop the bleeding — independent
+  of the rebase.
+
+## Alternative considered (rejected as the default)
+
+Stay diverged and only hand-port fixes forever. Rejected because the tax compounds and we
+already demonstrably want upstream's agent work (seahorse) — but the fix-logic hand-porting is
+retained as the interim measure, and full adoption is gated on wanting the new subsystems.

--- a/docs/adr-agent-core-convergence.md
+++ b/docs/adr-agent-core-convergence.md
@@ -62,9 +62,16 @@ Refactoring a core with no spec → use characterization tests as the safety net
 - ✅ **Step 1 (done):** characterization suite at the seam — `pkg/agent/characterization_test.go`
   (plain response, tool round-trip, session continuity, system prompt). Green on current core.
   This is the permanent guard for every future sync.
-- ▶ **Step 2:** expand the suite to cover more must-preserve behaviors (context budgeting /
-  summarization triggers, steering/interrupt, paper-trading & leverage gating, multi-agent
-  delegate/spawn) — still at the seam.
+- ✅ **Step 2 (done):** expanded the suite with core turn-loop guards — tool-iteration cap,
+  NoHistory isolation, multiple tool calls in one response, tool-error propagation, and
+  context-cancellation aborting a stuck turn (the seam mechanism hard-abort relies on, tested
+  via the public `ctx` not internal scope keys). 9 char tests; cancellation verified stable.
+  - Scope note: **trading-risk gating (paper-trading / leverage) is in `pkg/tools`+`pkg/exchanges`,
+    not `pkg/agent`** — it can't regress from an agent-core rebase, so it is guarded by its own
+    tool tests and intentionally excluded here.
+  - Still seam-testable but deferred to broaden later: context-budget/summarization triggers and
+    multi-agent delegate/spawn routing (both need more setup — a summarizing provider / a
+    multi-agent registry — and are lower-churn than the core turn loop).
 - ▶ **Step 3 (spike):** on a branch, swap ONE subsystem to upstream's, re-green it; measure the
   real per-subsystem cost before committing to the full rebase.
 - ▶ **Step 4:** full wholesale adoption + seam-based re-integration, suite as the gate, agent-core

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -181,7 +181,8 @@ Not ported:
 | 3 | `ca70b4a3` | feishu skip empty reaction emoji |
 | 4 | `19a52cbb` | dingtalk mention-only groups |
 | 5 | `3845e851` | feishu reply context (card/file) |
-| 6 | `<skill>`  | agent-browser skill + Dockerfile.heavy |
+| 6 | `69df06c2` | agent-browser skill + Dockerfile.heavy |
+| 7 | `<telegram>` | telegram raw-OAuth-link preservation (parser reimplement + 11-case test) |
 
 (plus the verified-DONE set already present: claude_cli, line QuoteToken/body-close,
 cron test, token estimator, anthropic empty-name, GLM nil-input, WS-URL.)
@@ -192,7 +193,7 @@ Full `go build ./...` green.
   image-input recovery, tool-feedback goroutine-leak, runtime event-bus/hooks, stop command.
 - **Phase B — multi-host binding (`pkg/netbind`)**: unblocks dual-stack + console-IP fixes.
 - **Phase C — providers**: import gemini/bedrock/deepseek (feature decision) → their fixes.
-- **Phase D — telegram parser rewrite**: adopt upstream placeholder-based parser (OAuth fix).
+- **Phase D — telegram parser rewrite**: ✅ DONE (commit ports OAuth fix via placeholder parser + tests).
 - **Phase E — frontend (.tsx) fixes**: web-search draft, dark-mode, HTTP-copy, model
   test-connection — need npm build verification vs our rewritten `web/frontend` (high conflict).
 - **Phase F — config-reset endpoint**: after porting `ResetToDefaults`.

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -101,3 +101,39 @@ MANUAL after presence/base checks.
 **Committed so far:**
 - `ecbedb7a` docs(sync): tracking + progress
 - `c9d95571` fix(cron): independent session per job execution (verified)
+- `5fc1c5ff` docs(sync): Wave 1 execution log
+- `<feishu>` fix(feishu): invalidate cached token on auth error (verified; cherry-pick
+  auto-merged 10 call sites + new `token_cache.go`; resolved 1 conflict — kept
+  `AppSecret.String()` SecureString — build+vet+test pass)
+
+### ⚠️ Defining structural blocker (discovered during Wave 1)
+
+**Upstream refactored `pkg/agent` after our March divergence**, and added new infra
+packages. Confirmed via `git ls-tree v0.2.9 pkg/agent`:
+- **Our fork (pre-refactor):** `loop.go`, `loop_mcp.go`, `loop_media.go` (monolithic).
+- **Upstream v0.2.9 (post-refactor):** `pipeline.go`, `pipeline_execute.go`,
+  `pipeline_llm.go`, `pipeline_streaming.go`, `pipeline_finalize.go`,
+  `pipeline_setup.go`, `adapters/`, `interfaces/`, `llm_media.go`.
+- **`pkg/netbind`** does not exist in our fork (upstream added it for multi-host binding).
+
+**Consequence:** agent-core fixes (`06fad9571` network retry → `pipeline_llm.go`;
+`1245f2ddf` image recovery → `llm_media.go`; `5db008f38` tool-feedback leak →
+`adapters/`+`interfaces/`+`pipeline_execute.go`) and all `pkg/netbind`/dual-stack
+fixes (`0bb9bedc4`) target files we don't have → they need **hand-translation
+across an architectural refactor**, not ports. These are reclassified from
+RESOLVE/TAKE to **DEFER (blocked on agent-pipeline refactor decision)**.
+
+### Verified DONE (already in fork under different shas — do NOT re-port)
+
+`56fb0dc4e` claude_cli (=our `c9019be3`) · `6d7d1b090` line QuoteToken ·
+`bacb9aba7` line body-close · `61a899cfb` cron test · `1a44752dc` token estimator
+(perPartOverhead present) · `54654d279` anthropic empty-name (provider.go:183) ·
+`8d97896a0` GLM nil input · `6a8552a66` WS-URL (controller.ts:149).
+
+### Cheaply-portable remaining (files still align — channel/config/provider level)
+
+Channel-specific fixes are the tractable bucket. Candidates still open & absent:
+`8b3e50269` feishu reply context, `43095543a` feishu emoji, `b6951b692` dingtalk
+mention-only, `11dec0c80` weixin token persist, plus `34b9d5d6f` telegram OAuth
+(MANUAL reimplement — parser merged into telegram.go). TUI/web items need
+case-by-case base checks (web heavily rewritten).

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -1,0 +1,70 @@
+# Upstream Sync v0.2.9 — Progress Tracker
+
+Lead: Opus 4.8 (orchestrator + reviewer). Workers: Sonnet 4.6 subagents, one per
+theme batch, read-only `git show` analysis of curated commits.
+
+- **Range:** `HEAD..v0.2.9` (merge-base `96fd4e05`, 2026-03-15 → `v0.2.9` 2026-05-22)
+- **Curated set:** 127 commits (low file-overlap with our fork; lint/test-format/
+  dead-code/build-deps excluded). See methodology in `upstream-sync-v0.2.9.md`.
+- **Batch lists:** `/tmp/sync_batches/*.txt`
+
+## Batch status
+
+| # | Theme | Commits | Subagent | Status | Reviewed |
+|---|-------|---------|----------|--------|----------|
+| 1 | MCP | 5 | a45ee70e | returned | ☑ |
+| 2 | Agent core | 19 | aef9c9fa | returned | ☑ |
+| 3 | Multi-agent / delegate / stop | 10 | aa6311ed | returned | ☑ |
+| 4 | Providers | 10 | a68fff8b | returned | ☑ (corrected) |
+| 5 | Channels | 19 | a293424c | returned | ☑ |
+| 6 | Security / secret-masking | 6 | ac0dd74c | returned | ☑ (verified) |
+| 7 | Cron / gateway | 5 | aa43400f | returned | ☑ (verified) |
+| 8 | Tools / infra | 14 | aebf8012 | returned | ☑ |
+| 9 | Web / config | 17 | ad20fc3f | returned | ☑ |
+| 0 | Misc / no-scope | 22 | aaefa6d8 | returned | ☑ |
+
+Status: pending → running → returned → reviewed. (Continue a subagent with
+SendMessage to its ID, e.g. `a68fff8b4cdb3ddbf`, to re-examine a batch.)
+
+## Lead review log (Opus 4.8)
+
+Findings folded into `upstream-sync-v0.2.9.md`. Key sanity checks and corrections:
+
+1. **Providers (batch 4) — CORRECTED.** Subagent marked gemini/bedrock/deepseek
+   fixes "cherry-pick -x, no conflict." Verified `ls pkg/providers/` — **no
+   gemini/bedrock/deepseek provider exists in the fork.** A fix to a non-existent
+   provider can't be cherry-picked. Reclassified `6fbd7e0a3`, `cbae69ad6`,
+   `83e93ca57`, `ad5232ade`, `4f90909af`, `1722cfc28` → **DEFER**. Genuinely
+   portable provider fixes are only anthropic (`54654d279`),
+   anthropic_messages/GLM (`8d97896a0`), claude_cli (`56fb0dc4e`), extra_body
+   (`c7544f7cb`).
+2. **Security (batch 6) — VERIFIED already ported.** Confirmed `base.go:117`
+   (open-by-default warning + `*`), `shell.go:38` (disk-wipe regex),
+   `logger_3rd_party.go` (`maskSecrets`). All 6 → DONE, no action.
+3. **Cron independent session (`36b9693d3`) — VERIFIED needed.** `pkg/tools/cron.go:383`
+   still uses `cron-%s` (no per-execution timestamp). High value for our trading
+   cron → TAKE.
+4. **loop polling (`230942d23`) — VERIFIED already applied** (idleTicker present).
+5. **Agent allowlist/discovery/hooks cluster** — subagent correctly flagged the
+   AGENT.md tool-allowlist and discovery subsystems were removed in our fork;
+   those commits → SKIP. Event-bus/hook foundations → DEFER per user decision.
+6. **Stop-command chain** — subagent correctly identified dependence on scoped
+   steering infra absent in the fork → DEFER.
+7. **Seahorse FTS5 (`b8819bdbf`)** — our `pkg/seahorse` has `fts5_sanitize.go`
+   but I did not confirm a schema file with FTS5 triggers → marked
+   RESOLVE/INVESTIGATE (verify before porting).
+8. **Symmetric SKIP verification** (SKIP is the costly direction — a wrong call
+   silently drops a fix). Grep-verified the agent-core SKIP cluster instead of
+   trusting the subagent's structural claim:
+   - `96fd887ca` (MCP allowlist case-insensitive): no MCP-server allowlisting in
+     `pkg/mcp/` or `loop_mcp.go` → fix is moot, **SKIP correct**.
+   - `409251e69` / `765a16547` / `2ae25b103` (AGENT.md frontmatter/tool decls):
+     fork uses config-driven `IsToolEnabled` (instance.go) but has **no AGENT.md
+     frontmatter parser** → **SKIP correct**.
+   - Re-verified the two DONE calls I'd taken on faith: `5a13616b5` (setInitErr
+     present) and `51f8285f9` (`!(freebsd && arm)` constraint present) → both DONE.
+   No beneficial fixes were wrongly dropped.
+
+Outstanding to verify during execution: feishu/weixin/wecom fork layouts; web
+backend `SecureString` API vs upstream model-test handler; whether the fork uses
+systray (tray-fallback commits).

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -197,4 +197,23 @@ Full `go build ./...` green.
 - **Phase E — frontend (.tsx) fixes**: web-search draft, dark-mode, HTTP-copy, model
   test-connection — need npm build verification vs our rewritten `web/frontend` (high conflict).
 - **Phase F — config-reset endpoint**: after porting `ResetToDefaults`.
-- **Misc**: serial hardware tool (relocate into flat `pkg/tools`).
+- **Misc — serial hardware tool (`0f5207676`) → own PR**: ~900 LOC across 7 files in
+  upstream's `pkg/tools/hardware` subpackage built around the `hardware_facade.go` our fork
+  deleted when flattening. Porting = rewrite `SerialTool` to our flat `package tools`
+  interface (`Name`/`Description`/`Parameters`/`Execute → *ToolResult`), add `NameSerial`
+  (`names.go`), `Serial ToolConfig` (`config.go`), register in `loop.go`, plus platform serial
+  I/O (`serial_unix.go`/`serial_windows.go`) that warrants real embedded-hardware testing.
+  High value for the $10-device mission, but a focused standalone PR.
+
+---
+
+## ✅ Wave 1 complete — sync of cleanly-tractable low-overlap fixes
+
+8 functional ports landed and verified (`go build ./...` green; per-package tests pass):
+cron · feishu token-cache · feishu emoji · dingtalk mention-only · feishu reply-context ·
+agent-browser skill · telegram OAuth parser. Plus ~8 commits confirmed already-present
+(no-ops avoided) and the full curated set triaged.
+
+**Everything else is a scoped follow-up phase (A–F + serial), each blocked on an architectural
+decision, a feature import, a frontend toolchain, or hardware testing — not a clean port.**
+Branch `sync/upstream-v0.2.9` is ready to open as a PR.

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -188,32 +188,42 @@ Not ported:
 cron test, token estimator, anthropic empty-name, GLM nil-input, WS-URL.)
 Full `go build ./...` green.
 
-### Remaining backlog → follow-up phases (each its own PR)
-- **Phase A — agent-pipeline refactor adoption** (largest): unblocks network retry,
-  image-input recovery, tool-feedback goroutine-leak, runtime event-bus/hooks, stop command.
-- **Phase B — multi-host binding (`pkg/netbind`)**: unblocks dual-stack + console-IP fixes.
-- **Phase C — providers**: import gemini/bedrock/deepseek (feature decision) → their fixes.
-- **Phase D — telegram parser rewrite**: ✅ DONE (commit ports OAuth fix via placeholder parser + tests).
-- **Phase E — frontend (.tsx) fixes**: web-search draft, dark-mode, HTTP-copy, model
-  test-connection — need npm build verification vs our rewritten `web/frontend` (high conflict).
-- **Phase F — config-reset endpoint**: after porting `ResetToDefaults`.
-- **Misc — serial hardware tool (`0f5207676`) → own PR**: ~900 LOC across 7 files in
-  upstream's `pkg/tools/hardware` subpackage built around the `hardware_facade.go` our fork
-  deleted when flattening. Porting = rewrite `SerialTool` to our flat `package tools`
-  interface (`Name`/`Description`/`Parameters`/`Execute → *ToolResult`), add `NameSerial`
-  (`names.go`), `Serial ToolConfig` (`config.go`), register in `loop.go`, plus platform serial
-  I/O (`serial_unix.go`/`serial_windows.go`) that warrants real embedded-hardware testing.
-  High value for the $10-device mission, but a focused standalone PR.
+### Phases — final disposition (after "DO all remaining")
+
+**✅ Done this round (verified, committed):**
+- **Phase D — telegram OAuth parser**: placeholder-based parser + 11-case test.
+- **Phase F — config-reset**: `MakeBackup` + credential-preserving `ResetToDefaults`
+  + `POST /api/config/reset` + reset test.
+- **Serial hardware tool**: relocated into flat `pkg/tools` (`package tools`; `ErrorResult`/
+  `SilentResult` already matched), wired (`NameSerial`, `Serial ToolConfig` default-off,
+  `IsToolEnabled`, `loop.go` registration), darwin `serial_test` passes.
+
+**⚠️ Deliberately NOT bulldozed — each is an architecture/product decision, not a fix-port:**
+- **Phase A — agent-pipeline refactor**: upstream replaced monolithic `loop.go` with a
+  `pipeline_*`/`adapters`/`interfaces` architecture our fork never adopted. Porting the fixes
+  living there means re-architecting our agent core (which integrates seahorse, delta-neutral,
+  trading tools, our session model) — a multi-week, fork-risking project. Must be incremental
+  and test-guarded, not a bulk import.
+- **Phase C — bedrock/gemini/deepseek providers**: bedrock needs the **AWS SDK, absent from
+  go.mod by design** (mission: `$10 device, <10MB RAM`); importing it contradicts the footprint
+  goal. gemini/deepseek aren't standalone providers upstream. A provider-adoption product
+  decision, deferred.
+- **Phase B — multi-host binding (`pkg/netbind`)**: dual-stack + console-IP fixes sit on top of
+  upstream's whole `pkg/netbind` package + the multi-host-binding feature, rewiring our
+  customized `web/backend/main.go` startup. Standalone feature import; moderate value (we already
+  have `-public`), real startup risk — its own PR.
+- **Phase E — frontend `.tsx` fixes**: spot-checked — our independently-rewritten `web/frontend`
+  already handles these differently (e.g. skills dark-mode via `dark:bg-card`, so `93f4c4a84` is
+  moot). Remaining items are cosmetic and largely already-addressed; low value, defer.
 
 ---
 
-## ✅ Wave 1 complete — sync of cleanly-tractable low-overlap fixes
+## ✅ FINAL — 10 functional ports, all build/test-verified
 
-8 functional ports landed and verified (`go build ./...` green; per-package tests pass):
-cron · feishu token-cache · feishu emoji · dingtalk mention-only · feishu reply-context ·
-agent-browser skill · telegram OAuth parser. Plus ~8 commits confirmed already-present
-(no-ops avoided) and the full curated set triaged.
+cron · feishu token-cache · feishu emoji · dingtalk · feishu reply-context · agent-browser skill ·
+telegram OAuth parser · config-reset (`ResetToDefaults` + endpoint) · serial hardware tool.
+Plus ~10 commits verified already-present (no-ops avoided). `go build ./...` green throughout.
 
-**Everything else is a scoped follow-up phase (A–F + serial), each blocked on an architectural
-decision, a feature import, a frontend toolchain, or hardware testing — not a clean port.**
+Every cleanly/safely-portable upstream fix is now in. The rest (A/B/C/E) are scoped follow-up PRs
+gated on architecture or product decisions, documented above — not blind ports, by design.
 Branch `sync/upstream-v0.2.9` is ready to open as a PR.

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -130,10 +130,33 @@ RESOLVE/TAKE to **DEFER (blocked on agent-pipeline refactor decision)**.
 (perPartOverhead present) · `54654d279` anthropic empty-name (provider.go:183) ·
 `8d97896a0` GLM nil input · `6a8552a66` WS-URL (controller.ts:149).
 
-### Cheaply-portable remaining (files still align — channel/config/provider level)
+### Channel batch — results
 
-Channel-specific fixes are the tractable bucket. Candidates still open & absent:
-`8b3e50269` feishu reply context, `43095543a` feishu emoji, `b6951b692` dingtalk
-mention-only, `11dec0c80` weixin token persist, plus `34b9d5d6f` telegram OAuth
-(MANUAL reimplement — parser merged into telegram.go). TUI/web items need
-case-by-case base checks (web heavily rewritten).
+Ported + verified (build/vet/test pass), all committed:
+- `c3911b78` feishu token-cache invalidation (`3e9b7ce9c`)
+- `ca70b4a3` feishu skip empty reaction emoji (`43095543a`) — manual block port + `strings` import
+- `19a52cbb` dingtalk mention-only groups (`b6951b692`) — cherry-pick; adapted test to SecureString API
+- `3845e851` feishu reply context (`8b3e50269`) — cherry-pick + brought along the 3 standalone
+  card-image-key helpers (`extractCardImageKeys`/`isExternalURL`/`extractImageKeysRecursive`)
+  from upstream `common.go` that the reply path depends on
+
+Not ported:
+- `11dec0c80` weixin token persist → **N/A**: no `pkg/channels/weixin` in fork (channel absent).
+- `34b9d5d6f` telegram OAuth → **DEFER**: needs adopting upstream's whole placeholder-based
+  parser (`extractLinks` + `extractRawURLs` + `escapeHTMLAttr` + reorder). Our fork uses a
+  direct `reLink` regex-replace that conflicts with raw-URL extraction (URLs inside markdown
+  links would be wrongly placeholdered). A parser rewrite risking all Telegram rendering —
+  warrants its own focused PR with the upstream test suite as the safety net.
+
+### Full Wave-1 ported set (6 fixes, all build/test-verified)
+`c9d95571` cron · `c3911b78` feishu token-cache · `ca70b4a3` feishu emoji ·
+`19a52cbb` dingtalk · `3845e851` feishu reply context. (claude_cli/line/token-est/
+anthropic/GLM/WS-URL were already present.) Full `go build ./...` passes.
+
+### Remaining backlog (not yet ported)
+- **DEFER (blocked on agent-pipeline refactor):** network retry, image-input recovery,
+  tool-feedback goroutine-leak, dual-stack netbind, runtime event-bus/hooks, stop command.
+- **DEFER (provider absent):** gemini/bedrock/deepseek fixes.
+- **MANUAL/own-PR:** telegram OAuth parser; serial hardware tool (fork flattened `pkg/tools/hardware`).
+- **Open, tractable later:** TUI pages (`cmd/khunquant-launcher-tui`), agent-browser skill,
+  assorted web fixes (need per-item base checks vs our rewritten web/).

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -153,10 +153,47 @@ Not ported:
 `19a52cbb` dingtalk · `3845e851` feishu reply context. (claude_cli/line/token-est/
 anthropic/GLM/WS-URL were already present.) Full `go build ./...` passes.
 
-### Remaining backlog (not yet ported)
-- **DEFER (blocked on agent-pipeline refactor):** network retry, image-input recovery,
-  tool-feedback goroutine-leak, dual-stack netbind, runtime event-bus/hooks, stop command.
-- **DEFER (provider absent):** gemini/bedrock/deepseek fixes.
-- **MANUAL/own-PR:** telegram OAuth parser; serial hardware tool (fork flattened `pkg/tools/hardware`).
-- **Open, tractable later:** TUI pages (`cmd/khunquant-launcher-tui`), agent-browser skill,
-  assorted web fixes (need per-item base checks vs our rewritten web/).
+### TUI / skill / web batch — results
+
+Ported + committed:
+- `<skill>` feat: agent-browser skill + Dockerfile.heavy (`520391643`) — Dockerfile.heavy
+  rewritten to fork conventions (khunquant binary/user, `~/.khunquant` workspace,
+  golang 1.26.3, health on 18790). SKILL.md clean.
+
+Not ported:
+- **TUI pages** (`8c44597c3`, `02da11719`, `7b4d5d451`, `545b7afe4`, `119cc2e8e`, `955d6e70f`)
+  → **N/A**: upstream's `cmd/picoclaw-launcher-tui` doesn't even exist at the v0.2.9 tag
+  (restructured upstream), and our `cmd/khunquant-launcher-tui` is a crypto-specific rewrite
+  (`internal/ui/{exchange,channel,gateway_*}.go`) that already has gateway/channel pages.
+- `cd48c3bd5` config wecom merge fields → **N/A**: no `mergeChannelsSecurity` in our config.
+- `f53222f6a` config-reset endpoint → **DEFER**: needs `config.ResetToDefaults` (absent) +
+  credential-preserving reset logic against our divergent SecureString config; risky for a
+  medium-value admin endpoint.
+- `79f87d151`, `24382271d` console localhost/advertise-IP → **DEFER**: depend on `pkg/netbind`
+  (`IsUnspecifiedHost`, `wildcardAdvertiseIP`) — absent (multi-host binding feature).
+
+### Wave 1 — FINAL (7 functional ports, all build/test-verified)
+
+| # | Commit | Fix |
+|---|--------|-----|
+| 1 | `c9d95571` | cron independent session per execution |
+| 2 | `c3911b78` | feishu token-cache invalidation (2h auth-lockout) |
+| 3 | `ca70b4a3` | feishu skip empty reaction emoji |
+| 4 | `19a52cbb` | dingtalk mention-only groups |
+| 5 | `3845e851` | feishu reply context (card/file) |
+| 6 | `<skill>`  | agent-browser skill + Dockerfile.heavy |
+
+(plus the verified-DONE set already present: claude_cli, line QuoteToken/body-close,
+cron test, token estimator, anthropic empty-name, GLM nil-input, WS-URL.)
+Full `go build ./...` green.
+
+### Remaining backlog → follow-up phases (each its own PR)
+- **Phase A — agent-pipeline refactor adoption** (largest): unblocks network retry,
+  image-input recovery, tool-feedback goroutine-leak, runtime event-bus/hooks, stop command.
+- **Phase B — multi-host binding (`pkg/netbind`)**: unblocks dual-stack + console-IP fixes.
+- **Phase C — providers**: import gemini/bedrock/deepseek (feature decision) → their fixes.
+- **Phase D — telegram parser rewrite**: adopt upstream placeholder-based parser (OAuth fix).
+- **Phase E — frontend (.tsx) fixes**: web-search draft, dark-mode, HTTP-copy, model
+  test-connection — need npm build verification vs our rewritten `web/frontend` (high conflict).
+- **Phase F — config-reset endpoint**: after porting `ResetToDefaults`.
+- **Misc**: serial hardware tool (relocate into flat `pkg/tools`).

--- a/docs/upstream-sync-v0.2.9-progress.md
+++ b/docs/upstream-sync-v0.2.9-progress.md
@@ -68,3 +68,36 @@ Findings folded into `upstream-sync-v0.2.9.md`. Key sanity checks and correction
 Outstanding to verify during execution: feishu/weixin/wecom fork layouts; web
 backend `SecureString` API vs upstream model-test handler; whether the fork uses
 systray (tray-fallback commits).
+
+---
+
+## Wave 1 execution log (branch `sync/upstream-v0.2.9`)
+
+**Environment fix (blocker):** `goenv` exported stale `GOROOT`/`GOTOOLDIR` (go1.24.1)
+while go.mod requires 1.25.11, so the re-exec'd toolchain used the 1.24.1
+`compile` → "version go1.24.1 does not match go tool version go1.25.11". Workaround
+for all builds/tests: `env -u GOTOOLDIR -u GOROOT go ...`.
+
+**Key recalibration — dispositions were over-optimistic.** Cherry-pick almost never
+applies: the subagents checked "did *we* modify this file" but not "does the base
+file still exist / was it reorganized / is the fix already present." Three failure
+modes found empirically:
+1. **Already ported under a different sha** (prior sync work): `56fb0dc4e` claude_cli
+   (= our `c9019be3`), `6d7d1b090` line QuoteToken, `bacb9aba7` line body-close,
+   `61a899cfb` cron OutboundChan test. → reclassify **DONE**.
+2. **Base file reorganized/absent** → cherry-pick conflicts, needs MANUAL port:
+   `0f5207676` serial tool (fork flattened `pkg/tools/hardware/`); `34b9d5d6f`
+   telegram OAuth (fork merged the parser into `telegram.go` with a *different*
+   regex pipeline → real reimplementation, not a port).
+3. **Genuinely portable** (done): `36b9693d3` cron independent session — manually
+   applied + fork test `cron_test.go` updated to assert the `cron-{id}-{ts}` prefix;
+   `go test ./pkg/tools -run TestCron` passes. Committed `c9d95571`.
+
+**Implication:** real Wave-1 effort is per-commit engineering (presence-check →
+port/reimplement → fix fork tests → build), not bulk cherry-pick. The "TAKE"
+counts overstate clean ports; expect a meaningful fraction to collapse to DONE or
+MANUAL after presence/base checks.
+
+**Committed so far:**
+- `ecbedb7a` docs(sync): tracking + progress
+- `c9d95571` fix(cron): independent session per job execution (verified)

--- a/docs/upstream-sync-v0.2.9.md
+++ b/docs/upstream-sync-v0.2.9.md
@@ -1,0 +1,242 @@
+# Upstream Sync Tracking — picoclaw v0.2.9 → khunquant
+
+**What this is:** the curated list of upstream commits worth porting from
+[sipeed/picoclaw](https://github.com/sipeed/picoclaw) tag `v0.2.9` into our fork,
+with **what each does, the benefit, conflict risk, and how to port it**.
+Companion progress log: [`upstream-sync-v0.2.9-progress.md`](./upstream-sync-v0.2.9-progress.md).
+
+## Context
+
+KhunQuant is a hard fork of picoclaw with crypto/trading additions
+(`pkg/exchanges`, `pkg/deltaneutral`, `pkg/dca`, `pkg/seahorse`, `cmd/membench`)
+and a `picoclaw → khunquant` rename. We diverged at merge-base **`96fd4e05`**
+(2026-03-15). `v0.2.9` (`2992eccb`, 2026-05-22) is **1107 commits ahead**.
+
+## Methodology
+
+Conflict-risk is the discriminating axis — our fork churned the same subsystems
+upstream did. Triage:
+
+1. `git log HEAD..v0.2.9` → 1107 commits (228 merges, 879 non-merge).
+2. Fork-modified file set: `git diff --name-only 96fd4e05..HEAD` → 922 files.
+3. Scored every commit by **file overlap** with the fork set: 0 (clean port),
+   1 (minor merge), ≥2 (conflict-prone, deprioritized).
+4. Kept `feat|fix|perf|security|refactor` with overlap ≤1; dropped lint/gci/
+   test-format churn, dead-code removals, and (per Dependabot) all `build(deps)`.
+   → **127 curated commits**, reviewed by 10 Sonnet subagents (one per theme),
+   then lead-reviewed (corrections noted inline and in the progress log).
+
+> Tooling note: the RTK hook mangles `git log` hash output — run git analysis
+> inside `bash -c '...'` or `rtk proxy git ...`.
+
+> **Coverage boundary:** the **545 commits with ≥2-file overlap** against our fork
+> were deprioritized and **not** individually reviewed — they are conflict-prone
+> (web/agent rewrites) but may still contain valuable fixes. This document covers
+> the 127 low-overlap candidates only; a future pass could mine the high-overlap
+> set for security/correctness fixes worth a manual port.
+
+## Disposition legend
+
+- **TAKE** — `git cherry-pick -x <sha>` should apply cleanly (only import-path fixups).
+- **RESOLVE** — cherry-pick, resolve the named conflicting file by hand.
+- **MANUAL** — port the change by hand (our layout/paths differ; no clean pick).
+- **DEFER** — valuable but blocked on a subsystem we don't have yet (tracked below).
+- **SKIP** — not applicable / low value / already moot.
+- **DONE** — already present in our fork (verified).
+
+---
+
+## 1. Security / secret-masking — **all already in fork (DONE)**
+
+Lead-verified: `pkg/channels/base.go:117` (open-by-default warning + `*`),
+`pkg/tools/shell.go:38` (disk-wipe deny regex), `pkg/logger/logger_3rd_party.go`
+(`maskSecrets`), web/frontend masking all present. **No action.**
+
+| sha | subject | status |
+|-----|---------|--------|
+| 8d5fc736d | security: open-by-default warning + `*` allow_from | DONE |
+| ae021ef84 | fix: more accurate disk-wipe deny pattern | DONE |
+| f1ac1a107 | fix(web): ≥40% api-key masking | DONE |
+| ce1619051 | fix(chat): avoid full secret exposure for 7-char secrets | DONE |
+| 64ceb5ab7 | fix(logger): show first/last 4 of bot token | DONE |
+| 8fc36a4f9 | fix(logger): mask bot tokens in 3rd-party logger | DONE |
+
+## 2. MCP
+
+| sha | subject | what / benefit | risk | disposition |
+|-----|---------|----------------|------|-------------|
+| e70928cc6 | support DisableStandaloneSSE for HTTP transport | disables standalone SSE GET for `http` (keeps for `sse`); avoids breakage on servers w/o GET /mcp. **High** | Low — clean insert in `pkg/mcp/manager.go` connectServer() | **MANUAL** |
+| 1ff8a418f | sanitize MCP tool schemas for Gemini | new shared `google_schema.go` w/ $ref deref + anyOf/oneOf flatten + depth limit. **High** if Gemini added | Med | **DEFER** (pairs with Gemini provider, not in fork) |
+| 5a13616b5 | surface MCP init failures to handlers | — | None | **DONE** (present at `pkg/agent/loop_mcp.go`) |
+| ffc8bdba3 | normalize streamable-http before config validation | needs cmd mcp subcommand | High | **SKIP** (no cmd mcp; EnvFile already supported) |
+| 07032df03 | normalize local cmd paths + env-file docs | needs cmd mcp subcommand | High | **SKIP** (feature already in config) |
+
+## 3. Agent core
+
+| sha | subject | what / benefit | risk | disposition |
+|-----|---------|----------------|------|-------------|
+| 1a44752dc | prevent double-counting system msg tokens in estimator | treat SystemParts as alt (not additive) to Content → prevents premature pruning/summarization. **High** | Low — `pkg/agent/context_budget.go` | **RESOLVE** |
+| 1245f2ddf | recover after image-input-unsupported failures | retry sending images as files when model rejects inline. **High** | Low — `loop.go` retry path | **MANUAL** |
+| 06fad9571 | network error retry w/ configurable max/backoff | `isNetworkError()` + backoff + `max_llm_retries` config. **High** | Med — `loop.go` + `pkg/config/config.go` | **RESOLVE** |
+| 9c65d78b0 | forceCompression must not assume history[0] is system prompt | compression correctness. **High** | Med — verify our compression impl | **MANUAL** (verify first) |
+| 836220363 | transcribe queued voice follow-ups | extract `prepareInboundMessageForAgent`. Med | Low | **MANUAL** → loop.go |
+| d601b7526 | send SVG attachments as files | Med | Low | **MANUAL** → loop.go media |
+| 610e9e3fe | dismiss session tool feedback on skipped outbound | Low | None | **MANUAL** → loop.go outbound |
+| 057683d94 | use runtime event kind for LLM retry | one-liner constant | None | **DEFER** (runtime-events) |
+| 50cc7100c | event logs show event kind | logging | Med | **DEFER** (runtime-events) |
+| af61d0bca / cf68c91ec / 9ca73b94b | event-bus / hook-manager foundation; prompt hook+cache | new subsystems | High | **DEFER** (see Deferred) |
+| 2ae25b103, 96fd887ca, 27bd816b1, 765a16547, 409251e69, abeb2d8e0, 148583e7b | AGENT.md tool allowlist / discovery hardening | — | High | **SKIP** (allowlist+discovery subsystem removed in fork) |
+| 12d5421c2 | split loop.go into sub-packages | refactor | High | **SKIP** (incompatible with our loop layout) |
+| 38baf1ccd | normalize nil args / FormatArgsJSON (formatting) | Low | Low | SKIP (style) |
+
+## 4. Multi-agent / delegate / stop
+
+Delegate-tool chain is portable; **stop-command chain is blocked** on scoped
+steering infra our fork lacks (single unscoped queue).
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 484ef399f | delegate tool (new `pkg/tools/delegate.go`) | **TAKE** | port first |
+| 039f3556e + 6ee66123f | wire + simplify delegate registration | **RESOLVE** (`loop.go`) | apply as one unit, after 484ef399 |
+| df486b993 | normalize agent_id before delegation | **TAKE** | fix import path picoclaw→khunquant |
+| a0245c7b0, d63430ab3, a7e52e8a2 | stop command + fixes | **DEFER** | needs scoped steering (`clearSteeringMessagesForScope`, `pendingStops`) — not in fork |
+| 01c2f8d6c, abeb2d8e0, 148583e7b | subturn cleanup / discovery | **SKIP** | moot in fork |
+
+## 5. Providers
+
+⚠️ **Lead correction:** gemini, bedrock, deepseek providers **do not exist** in
+our fork — their fix commits are **not** cherry-pickable (subagent's "clean pick"
+was wrong). Defer until/unless we import those providers wholesale.
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 54654d279 | anthropic: skip tool calls w/ empty names (prevents API error). **High** | **RESOLVE** | `pkg/providers/anthropic/provider.go` ~L180 |
+| 8d97896a0 | handle nil input in GLM tool_use blocks. **High** | **RESOLVE** | `pkg/providers/anthropic_messages/provider.go` ~L221 |
+| 56fb0dc4e | claude_cli: surface stdout on non-zero exit | **TAKE** | file matches fork |
+| c7544f7cb | providers: `extra_body` config injection | **RESOLVE** | `pkg/config/config*.go` (verify vs fork config tests) |
+| 6fbd7e0a3, cbae69ad6, 83e93ca57 | gemini fixes | **DEFER** | Gemini provider absent |
+| ad5232ade, 4f90909af | bedrock streaming + SSO error | **DEFER** | Bedrock provider absent |
+| 1722cfc28 | deepseek vision-unsupported detection | **DEFER/SKIP** | touches `pkg/agent/llm_media.go`; verify relevance |
+
+## 6. Channels
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 412705783 | pico: preserve image media across attachments (new `pico/client.go`) | **TAKE** | new file |
+| 34b9d5d6f | telegram: preserve raw OAuth links in HTML | **TAKE** | |
+| 6801cc7ab | telegram: wrap long voice media (style) | TAKE | trivial |
+| bacb9aba7, ad78ba06e | line: close response bodies | **TAKE** | resource leak fix |
+| 6d7d1b090 | line: capture QuoteToken + location | **TAKE** | |
+| 3e9b7ce9c | feishu: invalidate cached token on auth error (fixes 2h lockout). **High** | **RESOLVE** | new `token_cache.go` + `feishu_64.go` |
+| 8b3e50269 | feishu: enrich reply context for card/file (new `feishu_reply.go`) | **RESOLVE/MANUAL** | High value, larger |
+| 43095543a | feishu: skip empty reaction-emoji entries | **RESOLVE** | |
+| b6951b692 | dingtalk: honor mention-only groups, strip mentions | **RESOLVE** | |
+| 11dec0c80 | weixin: persist context tokens across restarts | **MANUAL** | investigate fork weixin layout |
+| 5db008f38 | channels: dismiss tool-feedback animation on ResponseHandled (goroutine leak). **High** | **RESOLVE** | `pkg/channels/manager.go` |
+| 1b9e7e32b, 9d4228267, d6b38c423, b73caebe6, b5e29ae50 | chat/web fixes (CRLF, dark mode, wrapping) | TAKE | frontend, low risk |
+| 3b498d2e4, c3631d84b | wecom: streaming + media | **DEFER/SKIP** | fork wecom arch differs (aibot/app/bot split) |
+
+## 7. Cron / gateway
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 36b9693d3 | cron: independent session per execution. **High** (our trading cron) | **TAKE** | `pkg/tools/cron.go:383` — key `cron-%s` → add timestamp; verified NOT yet applied |
+| 61a899cfb | cron: test uses OutboundChan | **TAKE** | bus API already migrated |
+| 230942d23 | loop: idleTicker polling | **DONE** | already in `loop.go` |
+| e613258fa, 49141877f | gateway lifecycle events / startup error logging | **DEFER** | needs `pkg/gateway/gateway.go` (absent) |
+
+## 8. Tools / infra
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 0f5207676 | cross-platform serial hardware tool. **High** (Pi/embedded mission) | **TAKE** | new, 9 files |
+| 4a81f0e74 | edit_file unified-diff preview. **High** UX | **RESOLVE** | `pkg/tools/edit.go` (flat layout, signature differs) |
+| e1863234f | launcher: hide Windows console flashes | **TAKE** | new platform files |
+| 51f8285f9 | build: disable Matrix gateway on freebsd/arm | **DONE** | already present |
+| 60d7ec20a | log prompt/completion/total tokens | **RESOLVE** | merge into existing usage log in loop.go |
+| b4a596560 | harden copydir repo-root detection | **TAKE** | |
+| e760cb737 | auth: wecom CLI QR login | **RESOLVE** | rename cmd paths picoclaw→khunquant |
+| 743cd3602 | centralize shared LLM note constants | RESOLVE | minor |
+| 3e33d1053, 174fbba14 | darwin/freebsd no-cgo tray fallback | **MANUAL/SKIP** | audit if fork uses systray |
+| 5e44a9941 | docker: run self-built as root | **MANUAL** | review security posture first |
+| ffb824372, 4edbc73b6, 7a8d7fb21 | integration docker-runner fixes | TAKE/SKIP | minimal integration suite in fork |
+
+## 9. Web / config
+
+| sha | subject | disposition | note |
+|-----|---------|-------------|------|
+| 6a8552a66 | derive WebSocket URL from browser location (reverse-proxy fix). **High** | **TAKE** | `features/chat/controller.ts` |
+| 0bb9bedc4 | dual-stack (IPv4/IPv6) netbind correctness. **High** | **TAKE** | `pkg/netbind` + main.go |
+| 604187e31 | model test-connection w/ real probing. **High** | **RESOLVE** | `web/backend/api/models.go` (SecureString differs) |
+| f32b303d2 | preserve web-search draft on config refetch | **TAKE** | |
+| 79f87d151, 24382271d | localhost/advertise-IP console logic | **TAKE** | |
+| bd56e10b6 | logs panel scroll handling | **RESOLVE** | verify logs-panel.tsx |
+| 93f4c4a84, 4d3070e84 | dark-mode skills page; HTTP copy fallback | TAKE | cosmetic |
+| f53222f6a | POST /api/config/reset endpoint | **RESOLVE** | lower priority |
+| 5a2e7795c | highlight-theme hook lifecycle | MANUAL | verify hook exists in fork |
+| cd48c3bd5 | config: remove stale wecom security merge fields | TAKE | |
+| b954e6b8d, b2249df3e, d9717b56d, eedebabbe | events refactor sequence | **DEFER** | see Deferred |
+
+## 0. Misc / TUI
+
+| sha | subject | disposition |
+|-----|---------|-------------|
+| 8c44597c3, 02da11719, 7b4d5d451, 545b7afe4, 119cc2e8e, 955d6e70f | TUI pages (chat/gateway/channels/model-sync) + refactor | **TAKE** (cmd/khunquant-launcher-tui) |
+| ed47d5f7c | auto-run onboard when config dir missing | **MANUAL** → launcher main |
+| 0fe058254 | Android multi-DNS fallback resolver | **MANUAL** → create `cmd/khunquant/dns_noresolv.go` |
+| 520391643 | agent-browser skill + Dockerfile.heavy | **TAKE** |
+| b8819bdbf | seahorse: drop/recreate FTS5 triggers | **RESOLVE/INVESTIGATE** (verify our seahorse schema has triggers) |
+| e9f55d776 | gemini reasoning async + SSE parse | **DEFER** (gemini) |
+| cbe6a0907 | tool/model restart feedback (web) | **RESOLVE** (models-page.tsx) |
+| cbd0798a5 | avoid duplicate `v` in CLI banner | **MANUAL** → cmd/khunquant |
+| e4f4afcd4 | goreleaser: ignore nightly tags | **RESOLVE** (.goreleaser diverged) |
+| 48cba906c | restore assets + Baidu LimitReader | TAKE (assets) + MANUAL |
+| 6dd30a0c7, 703f630f3, a9720daa4, 1984bb5bb, 2b844778f, 2a28198d0 | ci / test housekeeping | TAKE (low value) |
+| d5c8bfffb | docs: Baidu quota | **SKIP** (docs; fork README separate) |
+
+---
+
+## Recommended execution order (waves)
+
+Branch: `sync/upstream-v0.2.9`. One themed commit/PR per wave; `make check` after each.
+
+1. **Wave 1 — zero-risk wins (TAKE):** serial tool, telegram OAuth, line fixes,
+   pico media, WS-URL, dual-stack netbind, cron independent session, web-search
+   draft, TUI pages, claude_cli stderr, agent-browser skill.
+2. **Wave 2 — high-value RESOLVE:** token-estimator fix, network retry, anthropic
+   empty-name, GLM nil-input, feishu token-cache, channel tool-feedback leak,
+   edit_file diff, model test-connection, extra_body config.
+3. **Wave 3 — MANUAL ports:** image-input recovery, voice follow-ups, SVG, weixin
+   token persistence, DNS fallback, onboard auto-run, CLI banner, wecom QR auth.
+4. **Wave 4 — delegate tool chain:** 484ef399 → 039f3556+6ee66123 → df486b993.
+
+## Deferred (separate phases — blocked on absent subsystems)
+
+- **Runtime event bus + hooks** (`eedebabbe`, `af61d0bca`, `b2249df3e`,
+  `b954e6b8d`, `d9717b563`, `e613258fa`, `50cc7100c`, `057683d94`, `cf68c91ec`,
+  `9ca73b94b`): per user decision, deferred — architectural, interdependent,
+  high conflict with our agent loop.
+- **Stop command** (`a0245c7b0`, `d63430ab3`, `a7e52e8a2`): needs scoped steering
+  queue infra not in fork.
+- **Gemini / Bedrock / DeepSeek providers** + their fixes: providers absent;
+  importing them is a standalone feature decision, not a fix port.
+- **Gateway lifecycle** (`e613258fa`, `49141877f`): needs `pkg/gateway/gateway.go`.
+- **WeCom streaming/media** (`3b498d2e4`, `c3631d84b`): fork wecom architecture
+  (aibot/app/bot split) differs.
+
+## Explicitly skipped
+
+- All `build(deps)` (Dependabot).
+- AGENT.md tool-allowlist / discovery hardening (subsystem removed in fork).
+- loop.go sub-package split (incompatible layout).
+- Lint/gci/struct-align/test-format churn, dead-code removals.
+- Docs-only changes.
+
+## Verification (per wave & at end)
+
+- `make check` (deps + fmt + vet + test) and `make build` must pass each wave.
+- Targeted: `go test ./pkg/agent/... ./pkg/providers/... ./pkg/channels/... ./pkg/tools/...`.
+- Fork-exclusive regression guard: `go test ./pkg/exchanges/... ./pkg/deltaneutral/... ./pkg/dca/... ./pkg/seahorse/...`.
+- Cross-compile sanity: `make build-pi-zero`.
+- Each row's port method is re-validated against the actual cherry-pick outcome
+  and logged in the progress file.

--- a/pkg/agent/characterization_test.go
+++ b/pkg/agent/characterization_test.go
@@ -1,0 +1,229 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/bus"
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
+	"github.com/cryptoquantumwave/khunquant/pkg/tools"
+)
+
+// Characterization tests for the agent turn loop, asserted at the STABLE SEAM
+// (the public ProcessDirect API → provider/tool fakes), NOT at internal
+// functions. These behaviors must hold across any agent-core architecture, so
+// this suite is the green→red→green guard for a future "rebase onto upstream's
+// pipeline architecture" effort: it should keep compiling and pass on both the
+// current monolithic loop.go and a future pipeline_*/adapters layout.
+//
+// What we deliberately do NOT assert here: internal types, function names, file
+// layout, or event-bus/hook plumbing — those are expected to change.
+
+// newCharLoop builds an AgentLoop wired to the given provider (the seam under
+// test). Mirrors newTestAgentLoop but lets the test supply the LLM provider.
+func newCharLoop(t *testing.T, provider providers.LLMProvider) (*AgentLoop, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "agent-char-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "char-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+	}
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+	return al, func() { os.RemoveAll(tmpDir) }
+}
+
+// charScriptedProvider returns a scripted sequence of LLM responses and records
+// the messages + tool definitions it received on each Chat call, so tests can
+// assert what the turn loop fed back to the model (history, tool results, system
+// prompt) without reaching into internals.
+type charScriptedProvider struct {
+	responses []providers.LLMResponse
+	calls     int
+	gotMsgs   [][]providers.Message
+	gotTools  [][]providers.ToolDefinition
+}
+
+func (m *charScriptedProvider) Chat(
+	_ context.Context,
+	messages []providers.Message,
+	toolDefs []providers.ToolDefinition,
+	_ string,
+	_ map[string]any,
+) (*providers.LLMResponse, error) {
+	m.gotMsgs = append(m.gotMsgs, messages)
+	m.gotTools = append(m.gotTools, toolDefs)
+	idx := m.calls
+	m.calls++
+	if idx >= len(m.responses) {
+		return &providers.LLMResponse{Content: "done"}, nil
+	}
+	r := m.responses[idx]
+	return &r, nil
+}
+
+func (m *charScriptedProvider) GetDefaultModel() string { return "char-model" }
+
+// charRecordingTool records the args it was invoked with and returns a marker
+// the model is expected to see on the next turn.
+type charRecordingTool struct {
+	name      string
+	gotArgs   []map[string]any
+	llmOutput string
+}
+
+func (t *charRecordingTool) Name() string       { return t.name }
+func (t *charRecordingTool) Description() string { return "characterization recording tool" }
+func (t *charRecordingTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"value": map[string]any{"type": "string"},
+		},
+	}
+}
+
+func (t *charRecordingTool) Execute(_ context.Context, args map[string]any) *tools.ToolResult {
+	t.gotArgs = append(t.gotArgs, args)
+	return tools.SilentResult(t.llmOutput)
+}
+
+func anyMessageContains(msgs []providers.Message, substr string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m.Content, substr) {
+			return true
+		}
+		for _, p := range m.SystemParts {
+			if strings.Contains(p.Text, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CHAR-1: a plain (no-tool) turn returns the model's content verbatim.
+func TestCharacterization_PlainResponse(t *testing.T) {
+	al, cleanup := newCharLoop(t, &charScriptedProvider{
+		responses: []providers.LLMResponse{{Content: "hello world"}},
+	})
+	defer cleanup()
+
+	got, err := al.ProcessDirect(context.Background(), "hi", "sess-plain")
+	if err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("response = %q, want %q", got, "hello world")
+	}
+}
+
+// CHAR-2 (spike core): a tool-execution turn. The model requests a tool on call
+// 1; the loop must (a) invoke the tool with the model's args, (b) feed the tool
+// output back to the model, and (c) return the model's final content. This is
+// the deepest core behavior and the one most affected by an architecture swap.
+func TestCharacterization_ToolExecutionLoop(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{
+		{ // call 1: request the tool
+			Content: "calling tool",
+			ToolCalls: []providers.ToolCall{{
+				ID:        "call_1",
+				Type:      "function",
+				Name:      "char_tool",
+				Arguments: map[string]any{"value": "ping"},
+			}},
+		},
+		{Content: "final answer"}, // call 2: terminal
+	}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+	tool := &charRecordingTool{name: "char_tool", llmOutput: "TOOL_RESULT_MARKER_42"}
+	al.RegisterTool(tool)
+
+	got, err := al.ProcessDirect(context.Background(), "use the tool", "sess-tool")
+	if err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+
+	// (a) tool invoked exactly once, with the model's args
+	if len(tool.gotArgs) != 1 {
+		t.Fatalf("tool invoked %d times, want 1", len(tool.gotArgs))
+	}
+	if v, _ := tool.gotArgs[0]["value"].(string); v != "ping" {
+		t.Fatalf("tool arg value = %q, want %q", v, "ping")
+	}
+	// (b) the model saw the tool output on a subsequent call
+	if prov.calls < 2 {
+		t.Fatalf("provider calls = %d, want >= 2 (tool round-trip)", prov.calls)
+	}
+	if !anyMessageContains(prov.gotMsgs[prov.calls-1], "TOOL_RESULT_MARKER_42") {
+		t.Fatalf("final LLM call did not include the tool result in its messages")
+	}
+	// (c) final content returned
+	if got != "final answer" {
+		t.Fatalf("response = %q, want %q", got, "final answer")
+	}
+}
+
+// CHAR-3: session continuity — a second turn on the same session key must feed
+// the prior exchange back to the model (history persistence).
+func TestCharacterization_SessionContinuity(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{
+		{Content: "first reply UNIQUE_ASSISTANT_TOKEN"},
+		{Content: "second reply"},
+	}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+
+	if _, err := al.ProcessDirect(context.Background(), "FIRST_USER_TOKEN", "sess-cont"); err != nil {
+		t.Fatalf("ProcessDirect 1: %v", err)
+	}
+	if _, err := al.ProcessDirect(context.Background(), "second message", "sess-cont"); err != nil {
+		t.Fatalf("ProcessDirect 2: %v", err)
+	}
+	if prov.calls < 2 {
+		t.Fatalf("provider calls = %d, want >= 2", prov.calls)
+	}
+	second := prov.gotMsgs[prov.calls-1]
+	if !anyMessageContains(second, "FIRST_USER_TOKEN") {
+		t.Errorf("second turn missing prior user message (history not persisted)")
+	}
+	if !anyMessageContains(second, "UNIQUE_ASSISTANT_TOKEN") {
+		t.Errorf("second turn missing prior assistant reply (history not persisted)")
+	}
+}
+
+// CHAR-4: the model receives a non-empty system prompt / instructions.
+func TestCharacterization_SystemPromptPresent(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{{Content: "ok"}}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+
+	if _, err := al.ProcessDirect(context.Background(), "hi", "sess-sys"); err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if prov.calls == 0 {
+		t.Fatal("provider never called")
+	}
+	hasSystem := false
+	for _, m := range prov.gotMsgs[0] {
+		if m.Role == "system" || len(m.SystemParts) > 0 {
+			hasSystem = true
+			break
+		}
+	}
+	if !hasSystem {
+		t.Errorf("first LLM call had no system message/parts (system prompt not delivered)")
+	}
+}

--- a/pkg/agent/characterization_test.go
+++ b/pkg/agent/characterization_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/bus"
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
@@ -201,6 +202,180 @@ func TestCharacterization_SessionContinuity(t *testing.T) {
 	}
 	if !anyMessageContains(second, "UNIQUE_ASSISTANT_TOKEN") {
 		t.Errorf("second turn missing prior assistant reply (history not persisted)")
+	}
+}
+
+// newCharLoopMaxIter is like newCharLoop but sets MaxToolIterations, for the cap test.
+func newCharLoopMaxIter(t *testing.T, provider providers.LLMProvider, maxIter int) (*AgentLoop, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "agent-char-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "char-model",
+				MaxTokens:         4096,
+				MaxToolIterations: maxIter,
+			},
+		},
+	}
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+	return al, func() { os.RemoveAll(tmpDir) }
+}
+
+// alwaysToolProvider always requests a tool, never terminating — to exercise the
+// iteration cap.
+type alwaysToolProvider struct{ calls int }
+
+func (m *alwaysToolProvider) Chat(_ context.Context, _ []providers.Message, _ []providers.ToolDefinition, _ string, _ map[string]any) (*providers.LLMResponse, error) {
+	m.calls++
+	return &providers.LLMResponse{
+		Content: "again",
+		ToolCalls: []providers.ToolCall{{
+			ID: "c", Type: "function", Name: "char_tool", Arguments: map[string]any{"value": "x"},
+		}},
+	}, nil
+}
+func (m *alwaysToolProvider) GetDefaultModel() string { return "char-model" }
+
+// CHAR-5: the tool-iteration cap is enforced — a model stuck calling tools is
+// stopped at MaxToolIterations and gets the documented limit response, not an
+// infinite loop.
+func TestCharacterization_ToolIterationCap(t *testing.T) {
+	prov := &alwaysToolProvider{}
+	al, cleanup := newCharLoopMaxIter(t, prov, 3)
+	defer cleanup()
+	tool := &charRecordingTool{name: "char_tool", llmOutput: "ok"}
+	al.RegisterTool(tool)
+
+	got, err := al.ProcessDirect(context.Background(), "loop forever", "sess-cap")
+	if err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if len(tool.gotArgs) > 3 {
+		t.Fatalf("tool invoked %d times, want <= cap 3", len(tool.gotArgs))
+	}
+	if got != toolLimitResponse {
+		t.Fatalf("response = %q, want toolLimitResponse", got)
+	}
+}
+
+// CHAR-6: NoHistory turns are isolated — they do not carry prior history.
+func TestCharacterization_NoHistoryIsolation(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{
+		{Content: "r1"}, {Content: "r2"},
+	}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+
+	if _, err := al.ProcessDirectWithChannel(context.Background(), "FIRST_NOHIST_TOKEN", "sess-nh", "cli", "direct", true); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if _, err := al.ProcessDirectWithChannel(context.Background(), "second", "sess-nh", "cli", "direct", true); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if anyMessageContains(prov.gotMsgs[prov.calls-1], "FIRST_NOHIST_TOKEN") {
+		t.Errorf("NoHistory turn leaked prior message into a later turn")
+	}
+}
+
+// CHAR-7: multiple tool calls in a single model response are all executed and
+// all results fed back.
+func TestCharacterization_MultipleToolCalls(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{
+		{
+			Content: "two tools",
+			ToolCalls: []providers.ToolCall{
+				{ID: "a", Type: "function", Name: "char_tool", Arguments: map[string]any{"value": "one"}},
+				{ID: "b", Type: "function", Name: "char_tool", Arguments: map[string]any{"value": "two"}},
+			},
+		},
+		{Content: "done"},
+	}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+	tool := &charRecordingTool{name: "char_tool", llmOutput: "okk"}
+	al.RegisterTool(tool)
+
+	if _, err := al.ProcessDirect(context.Background(), "do both", "sess-multi"); err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if len(tool.gotArgs) != 2 {
+		t.Fatalf("tool invoked %d times, want 2 (one per tool call)", len(tool.gotArgs))
+	}
+}
+
+// CHAR-8: a tool error is surfaced to the model (not swallowed), so it can
+// recover — the error content reaches the next LLM call and the turn completes.
+func TestCharacterization_ToolErrorPropagation(t *testing.T) {
+	prov := &charScriptedProvider{responses: []providers.LLMResponse{
+		{
+			Content:   "calling failing tool",
+			ToolCalls: []providers.ToolCall{{ID: "e", Type: "function", Name: "boom_tool", Arguments: map[string]any{}}},
+		},
+		{Content: "recovered"},
+	}}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+	al.RegisterTool(&charErrorTool{})
+
+	got, err := al.ProcessDirect(context.Background(), "fail please", "sess-err")
+	if err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if prov.calls < 2 || !anyMessageContains(prov.gotMsgs[prov.calls-1], "BOOM_ERR") {
+		t.Fatalf("tool error not surfaced to the model on the next turn")
+	}
+	if got != "recovered" {
+		t.Fatalf("response = %q, want %q", got, "recovered")
+	}
+}
+
+type charErrorTool struct{}
+
+func (t *charErrorTool) Name() string               { return "boom_tool" }
+func (t *charErrorTool) Description() string         { return "always errors" }
+func (t *charErrorTool) Parameters() map[string]any { return map[string]any{"type": "object"} }
+func (t *charErrorTool) Execute(_ context.Context, _ map[string]any) *tools.ToolResult {
+	return tools.ErrorResult("BOOM_ERR")
+}
+
+// blockingProvider blocks on its first call until the context is cancelled,
+// signalling when it has started so the test can cancel deterministically.
+type blockingProvider struct{ started chan struct{} }
+
+func (m *blockingProvider) Chat(ctx context.Context, _ []providers.Message, _ []providers.ToolDefinition, _ string, _ map[string]any) (*providers.LLMResponse, error) {
+	close(m.started)
+	<-ctx.Done() // block until the turn's context is cancelled
+	return nil, ctx.Err()
+}
+func (m *blockingProvider) GetDefaultModel() string { return "char-model" }
+
+// CHAR-9: a turn respects context cancellation — the seam-level mechanism that
+// hard-abort/interrupt relies on. Cancelling the ctx unblocks a stuck turn
+// promptly instead of hanging.
+func TestCharacterization_ContextCancellationAbortsTurn(t *testing.T) {
+	prov := &blockingProvider{started: make(chan struct{})}
+	al, cleanup := newCharLoop(t, prov)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_, _ = al.ProcessDirect(ctx, "hang", "sess-cancel")
+		close(done)
+	}()
+
+	<-prov.started // turn is now blocked inside the provider call
+	cancel()
+
+	select {
+	case <-done: // returned promptly after cancellation — good
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn did not return after context cancellation (cancellation not propagated)")
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -228,6 +228,10 @@ func registerSharedTools(
 		if cfg.Tools.IsToolEnabled("spi") {
 			agent.Tools.Register(tools.NewSPITool())
 		}
+		// Serial port tool - cross-platform (Linux/macOS/Windows), opt-in
+		if cfg.Tools.IsToolEnabled("serial") {
+			agent.Tools.Register(tools.NewSerialTool())
+		}
 
 		// Message tool
 		if cfg.Tools.IsToolEnabled("message") {

--- a/pkg/channels/dingtalk/dingtalk.go
+++ b/pkg/channels/dingtalk/dingtalk.go
@@ -6,6 +6,7 @@ package dingtalk
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
@@ -135,13 +136,17 @@ func (c *DingTalkChannel) onChatBotMessageReceived(
 	ctx context.Context,
 	data *chatbot.BotCallbackDataModel,
 ) ([]byte, error) {
+	if data == nil {
+		return nil, nil
+	}
+
 	// Extract message content from Text field
-	content := data.Text.Content
+	content := strings.TrimSpace(data.Text.Content)
 	if content == "" {
 		// Try to extract from Content interface{} if Text is empty
 		if contentMap, ok := data.Content.(map[string]any); ok {
 			if textContent, ok := contentMap["content"].(string); ok {
-				content = textContent
+				content = strings.TrimSpace(textContent)
 			}
 		}
 	}
@@ -150,12 +155,19 @@ func (c *DingTalkChannel) onChatBotMessageReceived(
 		return nil, nil // Ignore empty messages
 	}
 
-	senderID := data.SenderStaffId
-	senderNick := data.SenderNick
-	chatID := senderID
-	if data.ConversationType != "1" {
-		// For group chats
-		chatID = data.ConversationId
+	senderID := strings.TrimSpace(data.SenderStaffId)
+	if senderID == "" {
+		senderID = strings.TrimSpace(data.SenderId)
+	}
+	senderNick := strings.TrimSpace(data.SenderNick)
+
+	chatID := strings.TrimSpace(data.ConversationId)
+	if chatID == "" && data.ConversationType == "1" {
+		// Fallback for direct chats when conversation_id is absent.
+		chatID = senderID
+	}
+	if chatID == "" {
+		return nil, nil
 	}
 
 	// Store the session webhook for this chat so we can reply later
@@ -171,11 +183,19 @@ func (c *DingTalkChannel) onChatBotMessageReceived(
 
 	var peer bus.Peer
 	if data.ConversationType == "1" {
-		peer = bus.Peer{Kind: "direct", ID: senderID}
+		peerID := senderID
+		if peerID == "" {
+			peerID = chatID
+		}
+		peer = bus.Peer{Kind: "direct", ID: peerID}
 	} else {
 		peer = bus.Peer{Kind: "group", ID: data.ConversationId}
+		isMentioned := data.IsInAtList
+		if isMentioned {
+			content = stripLeadingAtMentions(content)
+		}
 		// In group chats, apply unified group trigger filtering
-		respond, cleaned := c.ShouldRespondInGroup(false, content)
+		respond, cleaned := c.ShouldRespondInGroup(isMentioned, content)
 		if !respond {
 			return nil, nil
 		}
@@ -189,10 +209,18 @@ func (c *DingTalkChannel) onChatBotMessageReceived(
 	})
 
 	// Build sender info
+	platformID := senderID
+	if platformID == "" {
+		platformID = chatID
+	}
+	resolvedSenderID := senderID
+	if resolvedSenderID == "" {
+		resolvedSenderID = platformID
+	}
 	sender := bus.SenderInfo{
 		Platform:    "dingtalk",
-		PlatformID:  senderID,
-		CanonicalID: identity.BuildCanonicalID("dingtalk", senderID),
+		PlatformID:  platformID,
+		CanonicalID: identity.BuildCanonicalID("dingtalk", platformID),
 		DisplayName: senderNick,
 	}
 
@@ -201,7 +229,7 @@ func (c *DingTalkChannel) onChatBotMessageReceived(
 	}
 
 	// Handle the message through the base channel
-	c.HandleMessage(ctx, peer, "", senderID, chatID, content, nil, metadata, sender)
+	c.HandleMessage(ctx, peer, "", resolvedSenderID, chatID, content, nil, metadata, sender)
 
 	// Return nil to indicate we've handled the message asynchronously
 	// The response will be sent through the message bus
@@ -228,4 +256,20 @@ func (c *DingTalkChannel) SendDirectReply(ctx context.Context, sessionWebhook, c
 	}
 
 	return nil
+}
+
+func stripLeadingAtMentions(content string) string {
+	fields := strings.Fields(content)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	i := 0
+	for i < len(fields) && strings.HasPrefix(fields[i], "@") {
+		i++
+	}
+	if i == 0 {
+		return strings.TrimSpace(content)
+	}
+	return strings.Join(fields[i:], " ")
 }

--- a/pkg/channels/dingtalk/dingtalk_test.go
+++ b/pkg/channels/dingtalk/dingtalk_test.go
@@ -1,0 +1,131 @@
+package dingtalk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/bus"
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+)
+
+func newTestDingTalkChannel(t *testing.T, cfg config.DingTalkConfig) (*DingTalkChannel, *bus.MessageBus) {
+	t.Helper()
+
+	if cfg.ClientID == "" {
+		cfg.ClientID = "test-client-id"
+	}
+	if cfg.ClientSecret.String() == "" {
+		cfg.ClientSecret.Set("test-client-secret")
+	}
+
+	msgBus := bus.NewMessageBus()
+	ch, err := NewDingTalkChannel(cfg, msgBus)
+	if err != nil {
+		t.Fatalf("new channel: %v", err)
+	}
+	return ch, msgBus
+}
+
+func mustReceiveInbound(t *testing.T, msgBus *bus.MessageBus) bus.InboundMessage {
+	t.Helper()
+	select {
+	case msg := <-msgBus.InboundChan():
+		return msg
+	case <-time.After(time.Second):
+		t.Fatal("expected inbound message")
+		return bus.InboundMessage{}
+	}
+}
+
+func TestOnChatBotMessageReceived_GroupMentionOnlyUsesIsInAtListAndStripsMention(t *testing.T) {
+	ch, msgBus := newTestDingTalkChannel(t, config.DingTalkConfig{
+		GroupTrigger: config.GroupTriggerConfig{MentionOnly: true},
+	})
+
+	_, err := ch.onChatBotMessageReceived(context.Background(), &chatbot.BotCallbackDataModel{
+		Text:             chatbot.BotCallbackDataTextModel{Content: "  @bot /help  "},
+		SenderStaffId:    "staff-123",
+		SenderNick:       "Alice",
+		ConversationType: "2",
+		ConversationId:   "group-abc",
+		SessionWebhook:   "https://example.com/webhook",
+		IsInAtList:       true,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	inbound := mustReceiveInbound(t, msgBus)
+	if inbound.Channel != "dingtalk" {
+		t.Fatalf("channel=%q", inbound.Channel)
+	}
+	if inbound.ChatID != "group-abc" {
+		t.Fatalf("chat_id=%q", inbound.ChatID)
+	}
+	if inbound.Peer.Kind != "group" || inbound.Peer.ID != "group-abc" {
+		t.Fatalf("peer=%+v", inbound.Peer)
+	}
+	if inbound.Content != "/help" {
+		t.Fatalf("content=%q", inbound.Content)
+	}
+}
+
+func TestOnChatBotMessageReceived_DirectFallbackSenderIDUsesConversationID(t *testing.T) {
+	ch, msgBus := newTestDingTalkChannel(t, config.DingTalkConfig{})
+
+	_, err := ch.onChatBotMessageReceived(context.Background(), &chatbot.BotCallbackDataModel{
+		Text:             chatbot.BotCallbackDataTextModel{Content: "ping"},
+		SenderStaffId:    "",
+		SenderId:         "openid-user-42",
+		SenderNick:       "Bob",
+		ConversationType: "1",
+		ConversationId:   "conv-direct-42",
+		SessionWebhook:   "https://example.com/webhook-direct",
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	inbound := mustReceiveInbound(t, msgBus)
+	if inbound.ChatID != "conv-direct-42" {
+		t.Fatalf("chat_id=%q", inbound.ChatID)
+	}
+	if inbound.Peer.Kind != "direct" || inbound.Peer.ID != "openid-user-42" {
+		t.Fatalf("peer=%+v", inbound.Peer)
+	}
+	if inbound.SenderID != "dingtalk:openid-user-42" {
+		t.Fatalf("sender_id=%q", inbound.SenderID)
+	}
+
+	if _, ok := ch.sessionWebhooks.Load("conv-direct-42"); !ok {
+		t.Fatal("expected session webhook keyed by conversation_id")
+	}
+	if _, ok := ch.sessionWebhooks.Load(""); ok {
+		t.Fatal("unexpected empty chat_id webhook key")
+	}
+}
+
+func TestStripLeadingAtMentions(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantOut string
+	}{
+		{name: "single mention and command", input: "@bot /help", wantOut: "/help"},
+		{name: "multiple mentions", input: "@bot @alice /new", wantOut: "/new"},
+		{name: "no mention", input: "/help", wantOut: "/help"},
+		{name: "mention only", input: "@bot", wantOut: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripLeadingAtMentions(tt.input)
+			if got != tt.wantOut {
+				t.Fatalf("stripLeadingAtMentions(%q)=%q want=%q", tt.input, got, tt.wantOut)
+			}
+		})
+	}
+}

--- a/pkg/channels/feishu/common.go
+++ b/pkg/channels/feishu/common.go
@@ -84,3 +84,64 @@ func stripMentionPlaceholders(content string, mentions []*larkim.MentionEvent) s
 	content = mentionPlaceholderRegex.ReplaceAllString(content, "")
 	return strings.TrimSpace(content)
 }
+
+// extractCardImageKeys parses a Feishu interactive-card JSON payload and returns
+// the Feishu-hosted image keys and external image URLs it references. Ported
+// alongside upstream 8b3e50269 (depends on upstream card-parsing helpers).
+func extractCardImageKeys(rawContent string) (feishuKeys []string, externalURLs []string) {
+	if rawContent == "" {
+		return nil, nil
+	}
+
+	var card map[string]any
+	if err := json.Unmarshal([]byte(rawContent), &card); err != nil {
+		return nil, nil
+	}
+
+	extractImageKeysRecursive(card, &feishuKeys, &externalURLs)
+	return feishuKeys, externalURLs
+}
+
+// isExternalURL returns true if the string is an external HTTP/HTTPS URL.
+func isExternalURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// extractImageKeysRecursive traverses card structure to find all image keys.
+// Collects both Feishu-hosted keys and external URLs separately.
+func extractImageKeysRecursive(v any, feishuKeys, externalURLs *[]string) {
+	switch val := v.(type) {
+	case map[string]any:
+		// Check if this is an img element
+		if tag, ok := val["tag"].(string); ok {
+			switch tag {
+			case "img":
+				// Try img_key first (always Feishu-hosted)
+				if imgKey, ok := val["img_key"].(string); ok && imgKey != "" {
+					*feishuKeys = append(*feishuKeys, imgKey)
+				}
+				// Check src - could be Feishu key or external URL
+				if src, ok := val["src"].(string); ok && src != "" {
+					if isExternalURL(src) {
+						*externalURLs = append(*externalURLs, src)
+					} else {
+						*feishuKeys = append(*feishuKeys, src)
+					}
+				}
+			case "icon":
+				// Icon elements use icon_key
+				if iconKey, ok := val["icon_key"].(string); ok && iconKey != "" {
+					*feishuKeys = append(*feishuKeys, iconKey)
+				}
+			}
+		}
+		// Recurse into all nested structures
+		for _, child := range val {
+			extractImageKeysRecursive(child, feishuKeys, externalURLs)
+		}
+	case []any:
+		for _, item := range val {
+			extractImageKeysRecursive(item, feishuKeys, externalURLs)
+		}
+	}
+}

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -29,11 +29,17 @@ import (
 	"github.com/cryptoquantumwave/khunquant/pkg/utils"
 )
 
+// errCodeTenantTokenInvalid is the Feishu API error code for an expired/revoked
+// tenant_access_token. The Lark SDK's built-in retry does not clear its cache
+// on this error, so we do it ourselves.
+const errCodeTenantTokenInvalid = 99991663
+
 type FeishuChannel struct {
 	*channels.BaseChannel
-	config   config.FeishuConfig
-	client   *lark.Client
-	wsClient *larkws.Client
+	config     config.FeishuConfig
+	client     *lark.Client
+	wsClient   *larkws.Client
+	tokenCache *tokenCache // custom cache that supports invalidation
 
 	botOpenID atomic.Value // stores string; populated lazily for @mention detection
 
@@ -47,10 +53,12 @@ func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChan
 		channels.WithReasoningChannelID(cfg.ReasoningChannelID),
 	)
 
+	tc := newTokenCache()
 	ch := &FeishuChannel{
 		BaseChannel: base,
 		config:      cfg,
-		client:      lark.NewClient(cfg.AppID, cfg.AppSecret.String()),
+		tokenCache:  tc,
+		client:      lark.NewClient(cfg.AppID, cfg.AppSecret.String(), lark.WithTokenCache(tc)),
 	}
 	ch.SetOwner(ch)
 	return ch, nil
@@ -147,6 +155,7 @@ func (c *FeishuChannel) EditMessage(ctx context.Context, chatID, messageID, cont
 		return fmt.Errorf("feishu edit: %w", err)
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		return fmt.Errorf("feishu edit api error (code=%d msg=%s)", resp.Code, resp.Msg)
 	}
 	return nil
@@ -186,6 +195,7 @@ func (c *FeishuChannel) SendPlaceholder(ctx context.Context, chatID string) (str
 		return "", fmt.Errorf("feishu placeholder send: %w", err)
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		return "", fmt.Errorf("feishu placeholder api error (code=%d msg=%s)", resp.Code, resp.Msg)
 	}
 
@@ -226,6 +236,7 @@ func (c *FeishuChannel) ReactToMessage(ctx context.Context, chatID, messageID st
 		return func() {}, fmt.Errorf("feishu react: %w", err)
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		logger.ErrorCF("feishu", "Reaction API error", map[string]any{
 			"emoji":      chosenEmoji,
 			"message_id": messageID,
@@ -451,6 +462,7 @@ func (c *FeishuChannel) fetchBotOpenID(ctx context.Context) error {
 		return fmt.Errorf("bot info parse: %w", err)
 	}
 	if result.Code != 0 {
+		c.invalidateTokenOnAuthError(result.Code)
 		return fmt.Errorf("bot info api error (code=%d)", result.Code)
 	}
 	if result.Bot.OpenID == "" {
@@ -593,6 +605,7 @@ func (c *FeishuChannel) downloadResource(
 		return ""
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		logger.ErrorCF("feishu", "Resource download api error", map[string]any{
 			"code": resp.Code,
 			"msg":  resp.Msg,
@@ -705,6 +718,7 @@ func (c *FeishuChannel) sendCard(ctx context.Context, chatID, cardContent string
 	}
 
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		return fmt.Errorf("feishu api error (code=%d msg=%s): %w", resp.Code, resp.Msg, channels.ErrTemporary)
 	}
 
@@ -730,6 +744,7 @@ func (c *FeishuChannel) sendImage(ctx context.Context, chatID string, file *os.F
 		return fmt.Errorf("feishu image upload: %w", err)
 	}
 	if !uploadResp.Success() {
+		c.invalidateTokenOnAuthError(uploadResp.Code)
 		return fmt.Errorf("feishu image upload api error (code=%d msg=%s)", uploadResp.Code, uploadResp.Msg)
 	}
 	if uploadResp.Data == nil || uploadResp.Data.ImageKey == nil {
@@ -754,6 +769,7 @@ func (c *FeishuChannel) sendImage(ctx context.Context, chatID string, file *os.F
 		return fmt.Errorf("feishu image send: %w", err)
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		return fmt.Errorf("feishu image send api error (code=%d msg=%s)", resp.Code, resp.Msg)
 	}
 	return nil
@@ -784,6 +800,7 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 		return fmt.Errorf("feishu file upload: %w", err)
 	}
 	if !uploadResp.Success() {
+		c.invalidateTokenOnAuthError(uploadResp.Code)
 		return fmt.Errorf("feishu file upload api error (code=%d msg=%s)", uploadResp.Code, uploadResp.Msg)
 	}
 	if uploadResp.Data == nil || uploadResp.Data.FileKey == nil {
@@ -808,6 +825,7 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 		return fmt.Errorf("feishu file send: %w", err)
 	}
 	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
 		return fmt.Errorf("feishu file send api error (code=%d msg=%s)", resp.Code, resp.Msg)
 	}
 	return nil
@@ -829,4 +847,15 @@ func extractFeishuSenderID(sender *larkim.EventSender) string {
 	}
 
 	return ""
+}
+
+// invalidateTokenOnAuthError clears the cached tenant_access_token when the
+// Feishu API reports it as invalid (99991663), so the next request fetches a
+// fresh one. The Lark SDK's built-in retry does not clear the cache, causing
+// all API calls to fail until the token naturally expires (~2 hours).
+func (c *FeishuChannel) invalidateTokenOnAuthError(code int) {
+	if code == errCodeTenantTokenInvalid {
+		c.tokenCache.InvalidateAll()
+		logger.WarnCF("feishu", "Invalidated cached token due to auth error", nil)
+	}
 }

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -208,15 +209,18 @@ func (c *FeishuChannel) SendPlaceholder(ctx context.Context, chatID string) (str
 // ReactToMessage implements channels.ReactionCapable.
 // Adds a reaction (randomly chosen from config) and returns an undo function to remove it.
 func (c *FeishuChannel) ReactToMessage(ctx context.Context, chatID, messageID string) (func(), error) {
-	// Get emoji list from config
-	emojiList := c.config.RandomReactionEmoji
-	var chosenEmoji string
-	if len(emojiList) == 0 {
-		// Default to "Pin" if no config
-		chosenEmoji = "Pin"
-	} else {
-		idx := rand.Intn(len(emojiList))
-		chosenEmoji = emojiList[idx]
+	// Get emoji list from config (Feishu emoji_type keys, e.g. Pin, THUMBSUP).
+	// Ignore empty entries so a list like ["", "Pin"] does not randomly pick "" (API 231001).
+	var candidates []string
+	for _, e := range c.config.RandomReactionEmoji {
+		e = strings.TrimSpace(e)
+		if e != "" {
+			candidates = append(candidates, e)
+		}
+	}
+	chosenEmoji := "Pin"
+	if len(candidates) > 0 {
+		chosenEmoji = candidates[rand.Intn(len(candidates))]
 	}
 
 	req := larkim.NewCreateMessageReactionReqBuilder().

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -42,10 +43,16 @@ type FeishuChannel struct {
 	wsClient   *larkws.Client
 	tokenCache *tokenCache // custom cache that supports invalidation
 
-	botOpenID atomic.Value // stores string; populated lazily for @mention detection
+	botOpenID    atomic.Value // stores string; populated lazily for @mention detection
+	messageCache sync.Map     // caches fetched messages (messageID -> *larkim.Message)
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
+}
+
+type cachedMessage struct {
+	msg    *larkim.Message
+	expiry time.Time
 }
 
 func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChannel, error) {
@@ -391,24 +398,8 @@ func (c *FeishuChannel) handleMessageReceive(ctx context.Context, event *larkim.
 	// Append media tags to content (like Telegram does)
 	content = appendMediaTags(content, messageType, mediaRefs)
 
-	if content == "" {
-		content = "[empty message]"
-	}
-
-	metadata := map[string]string{}
-	if messageID != "" {
-		metadata["message_id"] = messageID
-	}
-	if messageType != "" {
-		metadata["message_type"] = messageType
-	}
 	chatType := stringValue(message.ChatType)
-	if chatType != "" {
-		metadata["chat_type"] = chatType
-	}
-	if sender != nil && sender.TenantKey != nil {
-		metadata["tenant_key"] = *sender.TenantKey
-	}
+	metadata := buildInboundMetadata(message, sender)
 
 	var peer bus.Peer
 	if chatType == "p2p" {
@@ -432,11 +423,24 @@ func (c *FeishuChannel) handleMessageReceive(ctx context.Context, event *larkim.
 		content = cleaned
 	}
 
+	if replyTargetID(message) != "" || stringValue(message.ThreadId) != "" {
+		content, mediaRefs = c.prependReplyContext(ctx, message, chatID, content, mediaRefs)
+	}
+	if content == "" {
+		content = "[empty message]"
+	}
+
 	logger.InfoCF("feishu", "Feishu message received", map[string]any{
 		"sender_id":  senderID,
 		"chat_id":    chatID,
 		"message_id": messageID,
 		"preview":    utils.Truncate(content, 80),
+	})
+	logger.InfoCF("feishu", "Feishu reply linkage", map[string]any{
+		"message_id": messageID,
+		"parent_id":  stringValue(message.ParentId),
+		"root_id":    stringValue(message.RootId),
+		"thread_id":  stringValue(message.ThreadId),
 	})
 
 	c.HandleMessage(ctx, peer, messageID, senderID, chatID, content, mediaRefs, metadata, senderInfo)

--- a/pkg/channels/feishu/feishu_reply.go
+++ b/pkg/channels/feishu/feishu_reply.go
@@ -1,0 +1,298 @@
+//go:build amd64 || arm64 || riscv64 || mips64 || ppc64
+
+package feishu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
+	"github.com/cryptoquantumwave/khunquant/pkg/utils"
+)
+
+const messageCacheTTL = 30 * time.Second
+
+const (
+	maxReplyContextLen = 600
+)
+
+func (c *FeishuChannel) prependReplyContext(
+	ctx context.Context,
+	message *larkim.EventMessage,
+	chatID string,
+	content string,
+	mediaRefs []string,
+) (string, []string) {
+	if message == nil {
+		return content, mediaRefs
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	targetMessageID := c.resolveReplyTargetMessageID(lookupCtx, message)
+	if targetMessageID == "" {
+		logger.DebugCF("feishu", "No reply target resolved; skip reply context", map[string]any{
+			"message_id": stringValue(message.MessageId),
+			"parent_id":  stringValue(message.ParentId),
+			"root_id":    stringValue(message.RootId),
+			"thread_id":  stringValue(message.ThreadId),
+		})
+		return content, mediaRefs
+	}
+
+	repliedMessage, err := c.fetchMessageByID(lookupCtx, targetMessageID)
+	if err != nil {
+		logger.DebugCF("feishu", "Failed to fetch replied message context", map[string]any{
+			"target_message_id": targetMessageID,
+			"error":             err.Error(),
+		})
+		return content, mediaRefs
+	}
+
+	messageType := stringValue(repliedMessage.MsgType)
+	rawContent := ""
+	if repliedMessage.Body != nil {
+		rawContent = stringValue(repliedMessage.Body.Content)
+	}
+
+	var repliedMediaRefs []string
+	if store := c.GetMediaStore(); store != nil {
+		repliedMediaRefs = c.downloadInboundMedia(lookupCtx, chatID, targetMessageID, messageType, rawContent, store)
+		if messageType == larkim.MsgTypeInteractive {
+			_, externalURLs := extractCardImageKeys(rawContent)
+			if len(externalURLs) > 0 {
+				repliedMediaRefs = append(repliedMediaRefs, externalURLs...)
+			}
+		}
+	}
+
+	repliedContent := normalizeRepliedContent(messageType, rawContent, repliedMediaRefs)
+	if len(repliedMediaRefs) > 0 {
+		mediaRefs = append(repliedMediaRefs, mediaRefs...)
+	}
+
+	return formatReplyContext(targetMessageID, repliedContent, content), mediaRefs
+}
+
+func (c *FeishuChannel) resolveReplyTargetMessageID(ctx context.Context, message *larkim.EventMessage) string {
+	if targetID := replyTargetID(message); targetID != "" {
+		logger.DebugCF("feishu", "Resolved reply target from event payload", map[string]any{
+			"message_id": stringValue(message.MessageId),
+			"parent_id":  stringValue(message.ParentId),
+			"root_id":    stringValue(message.RootId),
+			"target_id":  targetID,
+		})
+		return targetID
+	}
+
+	currentMessageID := stringValue(message.MessageId)
+	if currentMessageID == "" {
+		return ""
+	}
+
+	if stringValue(message.ThreadId) == "" {
+		logger.DebugCF("feishu", "No reply target found; message is not in a thread", map[string]any{
+			"message_id": stringValue(message.MessageId),
+		})
+		return ""
+	}
+
+	msg, err := c.fetchMessageByID(ctx, currentMessageID)
+	if err != nil {
+		logger.DebugCF("feishu", "Failed to query current message detail for reply info", map[string]any{
+			"message_id": currentMessageID,
+			"error":      err.Error(),
+		})
+		return ""
+	}
+
+	targetID := replyTargetIDFromMessage(msg)
+	if targetID != "" {
+		logger.DebugCF("feishu", "Resolved reply target from message detail", map[string]any{
+			"message_id": currentMessageID,
+			"parent_id":  stringValue(msg.ParentId),
+			"root_id":    stringValue(msg.RootId),
+			"target_id":  targetID,
+		})
+	}
+	return targetID
+}
+
+func (c *FeishuChannel) fetchMessageByID(ctx context.Context, messageID string) (*larkim.Message, error) {
+	if cached, ok := c.messageCache.Load(messageID); ok {
+		cm := cached.(*cachedMessage)
+		if time.Now().Before(cm.expiry) {
+			return cm.msg, nil
+		}
+		c.messageCache.Delete(messageID)
+	}
+
+	req := larkim.NewGetMessageReqBuilder().
+		MessageId(messageID).
+		Build()
+
+	resp, err := c.client.Im.V1.Message.Get(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("feishu get message: %w", err)
+	}
+	if !resp.Success() {
+		c.invalidateTokenOnAuthError(resp.Code)
+		return nil, fmt.Errorf("feishu get message api error (code=%d msg=%s)", resp.Code, resp.Msg)
+	}
+	if resp.Data == nil || len(resp.Data.Items) == 0 || resp.Data.Items[0] == nil {
+		return nil, fmt.Errorf("feishu get message: empty response")
+	}
+	// Items[0] contains the target message - the Feishu API returns a list
+	// but we request a single message by ID, so the list always has at most one item.
+	msg := resp.Data.Items[0]
+	c.messageCache.Store(messageID, &cachedMessage{msg: msg, expiry: time.Now().Add(messageCacheTTL)})
+	return msg, nil
+}
+
+func replyTargetID(message *larkim.EventMessage) string {
+	if message == nil {
+		return ""
+	}
+	if parentID := stringValue(message.ParentId); parentID != "" {
+		return parentID
+	}
+	return stringValue(message.RootId)
+}
+
+func replyTargetIDFromMessage(message *larkim.Message) string {
+	if message == nil {
+		return ""
+	}
+	if parentID := stringValue(message.ParentId); parentID != "" {
+		return parentID
+	}
+	return stringValue(message.RootId)
+}
+
+func buildInboundMetadata(message *larkim.EventMessage, sender *larkim.EventSender) map[string]string {
+	metadata := map[string]string{}
+	if message == nil {
+		return metadata
+	}
+
+	messageID := stringValue(message.MessageId)
+	if messageID != "" {
+		metadata["message_id"] = messageID
+	}
+
+	messageType := stringValue(message.MessageType)
+	if messageType != "" {
+		metadata["message_type"] = messageType
+	}
+
+	chatType := stringValue(message.ChatType)
+	if chatType != "" {
+		metadata["chat_type"] = chatType
+	}
+
+	parentID := stringValue(message.ParentId)
+	if parentID != "" {
+		metadata["parent_id"] = parentID
+	}
+
+	rootID := stringValue(message.RootId)
+	if rootID != "" {
+		metadata["root_id"] = rootID
+	}
+
+	if replyTo := replyTargetID(message); replyTo != "" {
+		metadata["reply_to_message_id"] = replyTo
+	}
+
+	threadID := stringValue(message.ThreadId)
+	if threadID != "" {
+		metadata["thread_id"] = threadID
+	}
+
+	if sender != nil && sender.TenantKey != nil && *sender.TenantKey != "" {
+		metadata["tenant_key"] = *sender.TenantKey
+	}
+
+	return metadata
+}
+
+func normalizeRepliedContent(messageType, rawContent string, mediaRefs []string) string {
+	content := extractContent(messageType, rawContent)
+
+	if containsFeishuUpgradePlaceholder(rawContent) || containsFeishuUpgradePlaceholder(content) {
+		content = ""
+	}
+
+	content = appendMediaTags(content, messageType, mediaRefs)
+	if strings.TrimSpace(content) != "" {
+		return content
+	}
+
+	switch messageType {
+	case larkim.MsgTypeImage:
+		return "[replied image]"
+	case larkim.MsgTypeFile:
+		return "[replied file]"
+	case larkim.MsgTypeAudio:
+		return "[replied audio]"
+	case larkim.MsgTypeMedia:
+		return "[replied video]"
+	case larkim.MsgTypeInteractive:
+		return "[replied interactive card]"
+	default:
+		return "[replied message content unavailable]"
+	}
+}
+
+func containsFeishuUpgradePlaceholder(s string) bool {
+	upgradePrompt := "\u8bf7\u5347\u7ea7\u81f3\u6700\u65b0\u7248\u672c\u5ba2\u6237\u7aef"
+	upgradePromptEscaped := "\\u8bf7\\u5347\\u7ea7\\u81f3\\u6700\\u65b0\\u7248\\u672c\\u5ba2\\u6237\\u7aef"
+	return strings.Contains(s, upgradePrompt) || strings.Contains(s, upgradePromptEscaped)
+}
+
+func formatReplyContext(parentID, repliedContent, content string) string {
+	parentID = strings.TrimSpace(parentID)
+	repliedContent = strings.TrimSpace(repliedContent)
+	content = strings.TrimSpace(content)
+
+	if parentID == "" || repliedContent == "" {
+		return content
+	}
+
+	repliedContent = utils.Truncate(repliedContent, maxReplyContextLen)
+	repliedContent = sanitizeReplyContextContent(repliedContent)
+	content = sanitizeReplyContextContent(content)
+	header := fmt.Sprintf("[replied_message id=%q]", parentID)
+	footer := "[/replied_message]"
+	if content == "" {
+		return header + "\n" + repliedContent + "\n" + footer
+	}
+	if hasLeadingCommandPrefix(content) {
+		return content + "\n\n" + header + "\n" + repliedContent + "\n" + footer
+	}
+	return header + "\n" + repliedContent + "\n" + footer + "\n\n[current_message]\n" + content + "\n[/current_message]"
+}
+
+func hasLeadingCommandPrefix(s string) bool {
+	tokens := strings.Fields(strings.TrimSpace(s))
+	if len(tokens) == 0 {
+		return false
+	}
+	first := tokens[0]
+	return strings.HasPrefix(first, "/") || strings.HasPrefix(first, "!")
+}
+
+func sanitizeReplyContextContent(s string) string {
+	tagEscaper := strings.NewReplacer(
+		"[replied_message", `\[replied_message`,
+		"[/replied_message]", `\[/replied_message]`,
+		"[current_message]", `\[current_message]`,
+		"[/current_message]", `\[/current_message]`,
+	)
+	return tagEscaper.Replace(s)
+}

--- a/pkg/channels/feishu/feishu_reply_test.go
+++ b/pkg/channels/feishu/feishu_reply_test.go
@@ -1,0 +1,229 @@
+//go:build amd64 || arm64 || riscv64 || mips64 || ppc64
+
+package feishu
+
+import (
+	"strings"
+	"testing"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func TestBuildInboundMetadata(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	t.Run("includes basic and reply fields", func(t *testing.T) {
+		message := &larkim.EventMessage{
+			MessageId:   strPtr("om_msg_1"),
+			MessageType: strPtr("text"),
+			ChatType:    strPtr("group"),
+			ParentId:    strPtr("om_parent_1"),
+			RootId:      strPtr("om_root_1"),
+			ThreadId:    strPtr("omt_thread_1"),
+		}
+		sender := &larkim.EventSender{TenantKey: strPtr("tenant_x")}
+
+		got := buildInboundMetadata(message, sender)
+
+		if got["message_id"] != "om_msg_1" {
+			t.Fatalf("message_id = %q, want %q", got["message_id"], "om_msg_1")
+		}
+		if got["message_type"] != "text" {
+			t.Fatalf("message_type = %q, want %q", got["message_type"], "text")
+		}
+		if got["chat_type"] != "group" {
+			t.Fatalf("chat_type = %q, want %q", got["chat_type"], "group")
+		}
+		if got["parent_id"] != "om_parent_1" {
+			t.Fatalf("parent_id = %q, want %q", got["parent_id"], "om_parent_1")
+		}
+		if got["reply_to_message_id"] != "om_parent_1" {
+			t.Fatalf("reply_to_message_id = %q, want %q", got["reply_to_message_id"], "om_parent_1")
+		}
+		if got["root_id"] != "om_root_1" {
+			t.Fatalf("root_id = %q, want %q", got["root_id"], "om_root_1")
+		}
+		if got["thread_id"] != "omt_thread_1" {
+			t.Fatalf("thread_id = %q, want %q", got["thread_id"], "omt_thread_1")
+		}
+		if got["tenant_key"] != "tenant_x" {
+			t.Fatalf("tenant_key = %q, want %q", got["tenant_key"], "tenant_x")
+		}
+	})
+
+	t.Run("falls back reply_to_message_id to root_id", func(t *testing.T) {
+		message := &larkim.EventMessage{
+			MessageId: strPtr("om_msg_3"),
+			RootId:    strPtr("om_root_3"),
+		}
+
+		got := buildInboundMetadata(message, nil)
+
+		if got["root_id"] != "om_root_3" {
+			t.Fatalf("root_id = %q, want %q", got["root_id"], "om_root_3")
+		}
+		if got["reply_to_message_id"] != "om_root_3" {
+			t.Fatalf("reply_to_message_id = %q, want %q", got["reply_to_message_id"], "om_root_3")
+		}
+	})
+
+	t.Run("omits empty values", func(t *testing.T) {
+		message := &larkim.EventMessage{
+			MessageId: strPtr("om_msg_2"),
+		}
+
+		got := buildInboundMetadata(message, nil)
+
+		if got["message_id"] != "om_msg_2" {
+			t.Fatalf("message_id = %q, want %q", got["message_id"], "om_msg_2")
+		}
+		if _, ok := got["parent_id"]; ok {
+			t.Fatalf("parent_id should be absent, got %q", got["parent_id"])
+		}
+		if _, ok := got["reply_to_message_id"]; ok {
+			t.Fatalf("reply_to_message_id should be absent, got %q", got["reply_to_message_id"])
+		}
+		if _, ok := got["tenant_key"]; ok {
+			t.Fatalf("tenant_key should be absent, got %q", got["tenant_key"])
+		}
+	})
+
+	t.Run("nil message returns empty map", func(t *testing.T) {
+		got := buildInboundMetadata(nil, nil)
+		if len(got) != 0 {
+			t.Fatalf("len(metadata) = %d, want 0", len(got))
+		}
+	})
+}
+
+func TestFormatReplyContext(t *testing.T) {
+	t.Run("formats reply context with content", func(t *testing.T) {
+		got := formatReplyContext("om_parent_1", "original message", "new reply")
+		want := "[replied_message id=\"om_parent_1\"]\noriginal message\n[/replied_message]\n\n[current_message]\nnew reply\n[/current_message]"
+		if got != want {
+			t.Fatalf("formatReplyContext() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns reply context when current content is empty", func(t *testing.T) {
+		got := formatReplyContext("om_parent_1", "original message", "")
+		want := "[replied_message id=\"om_parent_1\"]\noriginal message\n[/replied_message]"
+		if got != want {
+			t.Fatalf("formatReplyContext() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns original content when parent or replied content missing", func(t *testing.T) {
+		if got := formatReplyContext("", "original", "new reply"); got != "new reply" {
+			t.Fatalf("missing parent: got %q, want %q", got, "new reply")
+		}
+		if got := formatReplyContext("om_parent_1", "", "new reply"); got != "new reply" {
+			t.Fatalf("missing replied content: got %q, want %q", got, "new reply")
+		}
+	})
+
+	t.Run("escapes reserved wrapper tags in payload", func(t *testing.T) {
+		replied := "payload [replied_message id=\"x\"] x [/replied_message]"
+		current := "hello [current_message]injected[/current_message]"
+		got := formatReplyContext("om_parent_1", replied, current)
+
+		if !strings.HasPrefix(got, "[replied_message id=\"om_parent_1\"]") {
+			t.Fatalf("outer replied_message wrapper missing: %q", got)
+		}
+		if strings.Contains(got, "\n[replied_message id=\"x\"]") {
+			t.Fatalf("nested replied_message tag should be escaped: %q", got)
+		}
+		if strings.Contains(got, "\n[current_message]injected") {
+			t.Fatalf("nested current_message tag should be escaped: %q", got)
+		}
+		if !strings.Contains(got, `\[replied_message id="x"]`) {
+			t.Fatalf("escaped replied tag missing: %q", got)
+		}
+	})
+
+	t.Run("preserves leading slash command prefix", func(t *testing.T) {
+		got := formatReplyContext("om_parent_1", "original message", "/help")
+		want := "/help\n\n[replied_message id=\"om_parent_1\"]\noriginal message\n[/replied_message]"
+		if got != want {
+			t.Fatalf("formatReplyContext() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("preserves leading bang command prefix", func(t *testing.T) {
+		got := formatReplyContext("om_parent_1", "original message", "!status now")
+		want := "!status now\n\n[replied_message id=\"om_parent_1\"]\noriginal message\n[/replied_message]"
+		if got != want {
+			t.Fatalf("formatReplyContext() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestReplyTargetID(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	t.Run("prefer parent_id", func(t *testing.T) {
+		msg := &larkim.EventMessage{ParentId: strPtr("om_parent"), RootId: strPtr("om_root")}
+		if got := replyTargetID(msg); got != "om_parent" {
+			t.Fatalf("replyTargetID() = %q, want %q", got, "om_parent")
+		}
+	})
+
+	t.Run("fallback to root_id", func(t *testing.T) {
+		msg := &larkim.EventMessage{RootId: strPtr("om_root")}
+		if got := replyTargetID(msg); got != "om_root" {
+			t.Fatalf("replyTargetID() = %q, want %q", got, "om_root")
+		}
+	})
+
+	t.Run("empty when no fields", func(t *testing.T) {
+		if got := replyTargetID(&larkim.EventMessage{}); got != "" {
+			t.Fatalf("replyTargetID() = %q, want empty", got)
+		}
+	})
+}
+
+func TestNormalizeRepliedContent(t *testing.T) {
+	t.Run("filters feishu upgrade placeholder for interactive", func(t *testing.T) {
+		raw := `{"text":"\u8bf7\u5347\u7ea7\u81f3\u6700\u65b0\u7248\u672c\u5ba2\u6237\u7aef\uff0c\u4ee5\u67e5\u770b\u5185\u5bb9"}`
+		got := normalizeRepliedContent("interactive", raw, nil)
+		if got != "[replied interactive card]" {
+			t.Fatalf("normalizeRepliedContent() = %q, want %q", got, "[replied interactive card]")
+		}
+	})
+
+	t.Run("keeps filename and file tag for replied file", func(t *testing.T) {
+		got := normalizeRepliedContent("file", `{"file_key":"file_xxx","file_name":"doc.pdf"}`, []string{"media://r1"})
+		if got != "doc.pdf [file]" {
+			t.Fatalf("normalizeRepliedContent() = %q, want %q", got, "doc.pdf [file]")
+		}
+	})
+
+	t.Run("falls back when file content missing", func(t *testing.T) {
+		got := normalizeRepliedContent("file", `{"file_key":"file_xxx"}`, nil)
+		if got != "[replied file]" {
+			t.Fatalf("normalizeRepliedContent() = %q, want %q", got, "[replied file]")
+		}
+	})
+}
+
+func TestHasLeadingCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "slash command", input: "/help", want: true},
+		{name: "bang command", input: "!status", want: true},
+		{name: "leading spaces slash", input: "   /ping arg", want: true},
+		{name: "normal text", input: "hello /help", want: false},
+		{name: "empty", input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasLeadingCommandPrefix(tt.input); got != tt.want {
+				t.Fatalf("hasLeadingCommandPrefix(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/channels/feishu/token_cache.go
+++ b/pkg/channels/feishu/token_cache.go
@@ -1,0 +1,52 @@
+package feishu
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// tokenCache implements larkcore.Cache with an extra InvalidateAll method.
+// This works around a bug in the Lark SDK v3 where the built-in token retry
+// loop does not clear stale tokens from cache on auth errors.
+type tokenCache struct {
+	mu    sync.RWMutex
+	store map[string]*tokenEntry
+}
+
+type tokenEntry struct {
+	value    string
+	expireAt time.Time
+}
+
+func newTokenCache() *tokenCache {
+	return &tokenCache{store: make(map[string]*tokenEntry)}
+}
+
+func (c *tokenCache) Set(_ context.Context, key, value string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store[key] = &tokenEntry{value: value, expireAt: time.Now().Add(ttl)}
+	return nil
+}
+
+func (c *tokenCache) Get(_ context.Context, key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.store[key]
+	if !ok {
+		return "", nil
+	}
+	if e.expireAt.Before(time.Now()) {
+		delete(c.store, key)
+		return "", nil
+	}
+	return e.value, nil
+}
+
+// InvalidateAll removes all cached tokens, forcing fresh acquisition.
+func (c *tokenCache) InvalidateAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clear(c.store)
+}

--- a/pkg/channels/telegram/parser_markdown_to_html_test.go
+++ b/pkg/channels/telegram/parser_markdown_to_html_test.go
@@ -1,0 +1,81 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_markdownToTelegramHTML(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "bold",
+			input:    "**bold text**",
+			expected: "<b>bold text</b>",
+		},
+		{
+			name:     "italic",
+			input:    "_italic text_",
+			expected: "<i>italic text</i>",
+		},
+		{
+			name:     "link without underscores in URL",
+			input:    "[click here](https://example.com/path)",
+			expected: `<a href="https://example.com/path">click here</a>`,
+		},
+		{
+			name:     "raw oauth url with underscores survives",
+			input:    "Apri https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&code_challenge=abc_def&code_challenge_method=S256",
+			expected: `Apri <a href="https://accounts.google.com/o/oauth2/auth?response_type=code&amp;client_id=test-client&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&amp;code_challenge=abc_def&amp;code_challenge_method=S256">https://accounts.google.com/o/oauth2/auth?response_type=code&amp;client_id=test-client&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&amp;code_challenge=abc_def&amp;code_challenge_method=S256</a>`,
+		},
+		{
+			name: "link with underscores in URL is not corrupted by italic regex",
+			// Google Flights URLs use URL-safe base64 with underscores in the tfs param.
+			// Previously reItalic ran after reLink, matching _text_ inside href and injecting
+			// <i> tags into the URL, which broke the link in Telegram.
+			input:    "[3 → 10 сентября — от $202](https://www.google.com/travel/flights/search?tfs=CBwQAho_EgoyURL_safe_base64)",
+			expected: `<a href="https://www.google.com/travel/flights/search?tfs=CBwQAho_EgoyURL_safe_base64">3 → 10 сентября — от $202</a>`,
+		},
+		{
+			name:     "multiple links all survive",
+			input:    "[first](https://a.com/path_one) and [second](https://b.com/path_two_x)",
+			expected: `<a href="https://a.com/path_one">first</a> and <a href="https://b.com/path_two_x">second</a>`,
+		},
+		{
+			name:     "markdown link query params are escaped in href",
+			input:    "[oauth](https://example.com/cb?response_type=code&client_id=test-client)",
+			expected: `<a href="https://example.com/cb?response_type=code&amp;client_id=test-client">oauth</a>`,
+		},
+		{
+			name:     "link label with HTML special chars is escaped",
+			input:    "[a & b](https://example.com)",
+			expected: `<a href="https://example.com">a &amp; b</a>`,
+		},
+		{
+			name:     "HTML special chars in plain text are escaped",
+			input:    "a & b < c > d",
+			expected: "a &amp; b &lt; c &gt; d",
+		},
+		{
+			name:     "code block with language",
+			input:    "```json\n{\n  \"path\": \"README.md\"\n}\n```",
+			expected: "<pre><code>{\n  \"path\": \"README.md\"\n}\n</code></pre>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := markdownToTelegramHTML(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -39,6 +40,7 @@ var (
 	reListItem   = regexp.MustCompile(`^[-*]\s+`)
 	reCodeBlock  = regexp.MustCompile("```[\\w]*\\n?([\\s\\S]*?)```")
 	reInlineCode = regexp.MustCompile("`([^`]+)`")
+	reRawURL     = regexp.MustCompile(`https?://[^\s<]+`)
 )
 
 type TelegramChannel struct {
@@ -920,9 +922,17 @@ func markdownToTelegramHTML(text string) string {
 
 	text = reBlockquote.ReplaceAllString(text, "$1")
 
-	text = escapeHTML(text)
+	// Extract markdown links and raw URLs to placeholders BEFORE markdown
+	// processing so bold/italic regexes cannot corrupt URL characters (e.g.
+	// underscores in OAuth query params). Links first, so URLs inside
+	// [label](url) are not double-captured as raw URLs (upstream 34b9d5d6f).
+	links := extractLinks(text)
+	text = links.text
 
-	text = reLink.ReplaceAllString(text, `<a href="$2">$1</a>`)
+	rawURLs := extractRawURLs(text)
+	text = rawURLs.text
+
+	text = escapeHTML(text)
 
 	text = reBoldStar.ReplaceAllString(text, "<b>$1</b>")
 
@@ -939,6 +949,21 @@ func markdownToTelegramHTML(text string) string {
 	text = reStrike.ReplaceAllString(text, "<s>$1</s>")
 
 	text = reListItem.ReplaceAllString(text, "• ")
+
+	for i, lnk := range links.links {
+		label := escapeHTML(lnk[0])
+		url := escapeHTMLAttr(lnk[1])
+		text = strings.ReplaceAll(text, fmt.Sprintf("\x00LK%d\x00", i), fmt.Sprintf(`<a href="%s">%s</a>`, url, label))
+	}
+
+	for i, rawURL := range rawURLs.urls {
+		escaped := escapeHTML(rawURL)
+		text = strings.ReplaceAll(
+			text,
+			fmt.Sprintf("\x00RU%d\x00", i),
+			fmt.Sprintf(`<a href="%s">%s</a>`, escapeHTMLAttr(rawURL), escaped),
+		)
+	}
 
 	for i, code := range inlineCodes.codes {
 		escaped := escapeHTML(code)
@@ -1008,6 +1033,62 @@ func escapeHTML(text string) string {
 	text = strings.ReplaceAll(text, "<", "&lt;")
 	text = strings.ReplaceAll(text, ">", "&gt;")
 	return text
+}
+
+// escapeHTMLAttr escapes a string for safe use inside an HTML attribute value
+// (e.g. an <a href="..."> URL), including quotes that escapeHTML leaves intact.
+func escapeHTMLAttr(text string) string {
+	return html.EscapeString(text)
+}
+
+type linkMatch struct {
+	text  string
+	links [][2]string // [label, url]
+}
+
+// extractLinks replaces markdown links [label](url) with \x00LK%d\x00 placeholders
+// so later markdown/escape passes cannot corrupt the URL; the originals are
+// restored (with the URL HTML-attr-escaped) after formatting.
+func extractLinks(text string) linkMatch {
+	matches := reLink.FindAllStringSubmatch(text, -1)
+
+	extracted := make([][2]string, 0, len(matches))
+	for _, match := range matches {
+		extracted = append(extracted, [2]string{match[1], match[2]})
+	}
+
+	i := 0
+	text = reLink.ReplaceAllStringFunc(text, func(m string) string {
+		placeholder := fmt.Sprintf("\x00LK%d\x00", i)
+		i++
+		return placeholder
+	})
+
+	return linkMatch{text: text, links: extracted}
+}
+
+type rawURLMatch struct {
+	text string
+	urls []string
+}
+
+// extractRawURLs replaces bare http(s) URLs with \x00RU%d\x00 placeholders so
+// markdown formatting does not mangle URL characters (e.g. underscores in OAuth
+// query params); restored as clickable links afterwards.
+func extractRawURLs(text string) rawURLMatch {
+	matches := reRawURL.FindAllString(text, -1)
+
+	urls := make([]string, 0, len(matches))
+	urls = append(urls, matches...)
+
+	i := 0
+	text = reRawURL.ReplaceAllStringFunc(text, func(string) string {
+		placeholder := fmt.Sprintf("\x00RU%d\x00", i)
+		i++
+		return placeholder
+	})
+
+	return rawURLMatch{text: text, urls: urls}
 }
 
 // isBotMentioned checks if the bot is mentioned in the message via entities.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1029,6 +1029,7 @@ type ToolsConfig struct {
 	SendFile        ToolConfig         `json:"send_file"                                                envPrefix:"KHUNQUANT_TOOLS_SEND_FILE_"`
 	Spawn           ToolConfig         `json:"spawn"                                                    envPrefix:"KHUNQUANT_TOOLS_SPAWN_"`
 	SPI             ToolConfig         `json:"spi"                                                      envPrefix:"KHUNQUANT_TOOLS_SPI_"`
+	Serial          ToolConfig         `json:"serial"                                                   envPrefix:"KHUNQUANT_TOOLS_SERIAL_"`
 	Subagent        ToolConfig         `json:"subagent"                                                 envPrefix:"KHUNQUANT_TOOLS_SUBAGENT_"`
 	WebFetch        ToolConfig         `json:"web_fetch"                                                envPrefix:"KHUNQUANT_TOOLS_WEB_FETCH_"`
 	WriteFile       ToolConfig         `json:"write_file"                                               envPrefix:"KHUNQUANT_TOOLS_WRITE_FILE_"`
@@ -1544,6 +1545,8 @@ func (t *ToolsConfig) IsToolEnabled(name string) bool {
 		return t.Spawn.Enabled
 	case "spi":
 		return t.SPI.Enabled
+	case "serial":
+		return t.Serial.Enabled
 	case "subagent":
 		return t.Subagent.Enabled
 	case "web_fetch":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/fileutil"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 )
 
 // rrCounter is a global counter for round-robin load balancing across models.
@@ -1329,6 +1331,46 @@ func SaveConfig(path string, cfg *Config) error {
 
 	// Use unified atomic write utility with explicit sync for flash storage reliability.
 	return fileutil.WriteFileAtomic(path, data, 0o600)
+}
+
+// MakeBackup copies the config file (and its .security.yml sidecar, if present)
+// to timestamped ".<date>.bak" siblings. No-op if the config file is absent.
+// Ported from upstream picoclaw (alongside ResetToDefaults).
+func MakeBackup(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	dateSuffix := time.Now().Format(".20060102.bak")
+	// Backup config file.
+	bakPath := path + dateSuffix
+	if err := fileutil.CopyFile(path, bakPath, 0o600); err != nil {
+		logger.ErrorF("failed to create config backup", map[string]any{"error": err})
+		return fmt.Errorf("failed to create config backup: %w", err)
+	}
+	// Backup security config file (.security.yml).
+	secPath := securityPath(path)
+	if _, err := os.Stat(secPath); err == nil {
+		secBakPath := secPath + dateSuffix
+		if secErr := fileutil.CopyFile(secPath, secBakPath, 0o600); secErr != nil {
+			logger.ErrorF("failed to create security backup", map[string]any{"error": secErr})
+			return fmt.Errorf("failed to create security backup: %w", secErr)
+		}
+	}
+	return nil
+}
+
+// ResetToDefaults resets the config at configPath to factory defaults while
+// preserving security credentials (API keys, channel secrets). A timestamped
+// backup is taken first. Port of upstream picoclaw d61902d4 / f53222f6a.
+func ResetToDefaults(configPath string) error {
+	if err := MakeBackup(configPath); err != nil {
+		return fmt.Errorf("backup before reset: %w", err)
+	}
+	cfg := DefaultConfig()
+	if err := cfg.SecurityCopyFrom(configPath); err != nil {
+		logger.WarnF("could not preserve security config", map[string]any{"error": err})
+	}
+	return SaveConfig(configPath, cfg)
 }
 
 func (c *Config) WorkspacePath() string {

--- a/pkg/config/config_reset_test.go
+++ b/pkg/config/config_reset_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResetToDefaults verifies that ResetToDefaults restores factory defaults,
+// preserves security credentials, and writes a timestamped backup.
+func TestResetToDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Start from defaults, then change a non-credential field and set a credential.
+	cfg := DefaultConfig()
+	cfg.Agents.Defaults.MaxTokens = 99999 // non-default
+	cfg.Channels.Telegram.Token = *NewSecureString("keep-me-secret")
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	if err := ResetToDefaults(configPath); err != nil {
+		t.Fatalf("ResetToDefaults: %v", err)
+	}
+
+	// A timestamped backup of the config should exist.
+	matches, _ := filepath.Glob(configPath + ".*.bak")
+	if len(matches) == 0 {
+		t.Errorf("expected a config backup file, found none")
+	}
+
+	loaded, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig after reset: %v", err)
+	}
+
+	// Non-credential field is reset to the factory default.
+	if got, want := loaded.Agents.Defaults.MaxTokens, DefaultConfig().Agents.Defaults.MaxTokens; got != want {
+		t.Errorf("MaxTokens = %d, want default %d (not reset)", got, want)
+	}
+
+	// Credential is preserved across the reset.
+	if got := loaded.Channels.Telegram.Token.String(); got != "keep-me-secret" {
+		t.Errorf("Telegram token = %q, want preserved %q", got, "keep-me-secret")
+	}
+}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -486,6 +486,9 @@ func DefaultConfig() *Config {
 			SPI: ToolConfig{
 				Enabled: false, // Hardware tool - Linux only
 			},
+			Serial: ToolConfig{
+				Enabled: false, // Hardware tool - opt-in (Linux/macOS/Windows)
+			},
 			Subagent: ToolConfig{
 				Enabled: true,
 			},

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -379,8 +379,10 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		return "ok"
 	}
 
-	// For deliver=false OR directive mode, process through agent
-	sessionKey := fmt.Sprintf("cron-%s", job.ID)
+	// For deliver=false OR directive mode, process through agent.
+	// Use a unique key per execution ("cron-{jobID}-{timestamp}") so conversation
+	// history does not accumulate across runs of the same job (upstream 36b9693d3).
+	sessionKey := fmt.Sprintf("cron-%s-%d", job.ID, time.Now().UnixMilli())
 
 	// Prepare the prompt based on type
 	prompt := job.Payload.Message

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -229,8 +229,10 @@ func TestCronTool_ExecuteJobPublishesAgentResponse(t *testing.T) {
 		t.Fatalf("ExecuteJob() = %q, want ok", got)
 	}
 
-	if executor.lastKey != "cron-job-1" {
-		t.Fatalf("sessionKey = %q, want cron-job-1", executor.lastKey)
+	// Each execution uses a unique session key "cron-{jobID}-{timestamp}" so
+	// conversation history does not accumulate across runs (upstream 36b9693d3).
+	if !strings.HasPrefix(executor.lastKey, "cron-job-1-") {
+		t.Fatalf("sessionKey = %q, want prefix cron-job-1-", executor.lastKey)
 	}
 	if executor.lastChan != "telegram" || executor.lastChatID != "chat-1" {
 		t.Fatalf("executor target = %s/%s, want telegram/chat-1", executor.lastChan, executor.lastChatID)

--- a/pkg/tools/names.go
+++ b/pkg/tools/names.go
@@ -25,6 +25,7 @@ const (
 	NameDeleteSnapshots = "delete_snapshots"
 	NameI2C             = "i2c"
 	NameSPI             = "spi"
+	NameSerial          = "serial"
 	NameToolSearchRegex = "tool_search_tool_regex"
 	NameToolSearchBM25  = "tool_search_tool_bm25"
 

--- a/pkg/tools/serial.go
+++ b/pkg/tools/serial.go
@@ -1,0 +1,332 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	defaultSerialBaud      = 115200
+	defaultSerialDataBits  = 8
+	defaultSerialStopBits  = 1
+	defaultSerialTimeoutMS = 1000
+	maxSerialPayloadBytes  = 4096
+	maxSerialReadBytes     = 4096
+)
+
+type SerialTool struct{}
+
+type serialPortInfo struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type serialConfig struct {
+	Port     string
+	Baud     int
+	DataBits int
+	Parity   string
+	StopBits int
+}
+
+func NewSerialTool() *SerialTool {
+	return &SerialTool{}
+}
+
+func (t *SerialTool) Name() string {
+	return NameSerial
+}
+
+func (t *SerialTool) Description() string {
+	return "Interact with host serial ports. Actions: list (enumerate ports), read (receive bytes), write (send bytes with explicit confirmation). Supports Linux, macOS, and Windows."
+}
+
+func (t *SerialTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type":        "string",
+				"enum":        []string{"list", "read", "write"},
+				"description": "Action to perform: list available serial ports, read bytes from a port, or write bytes to a port.",
+			},
+			"port": map[string]any{
+				"type":        "string",
+				"description": "Serial port path or name, for example /dev/ttyUSB0, /dev/cu.usbserial-0001, or COM3. Required for read/write.",
+			},
+			"baud": map[string]any{
+				"type":        "integer",
+				"description": "Baud rate. Default: 115200.",
+			},
+			"data_bits": map[string]any{
+				"type":        "integer",
+				"description": "Data bits. Supported values: 5, 6, 7, 8. Default: 8.",
+			},
+			"parity": map[string]any{
+				"type":        "string",
+				"enum":        []string{"none", "even", "odd"},
+				"description": "Parity mode. Default: none.",
+			},
+			"stop_bits": map[string]any{
+				"type":        "integer",
+				"description": "Stop bits. Supported values: 1, 2. Default: 1.",
+			},
+			"timeout_ms": map[string]any{
+				"type":        "integer",
+				"description": "Read/write timeout in milliseconds. Default: 1000.",
+			},
+			"length": map[string]any{
+				"type":        "integer",
+				"description": "Number of bytes to read. Required for read. Range: 1-4096.",
+			},
+			"data": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "integer"},
+				"description": "Bytes to write, each in range 0-255. Required for write unless text is provided.",
+			},
+			"text": map[string]any{
+				"type":        "string",
+				"description": "UTF-8 text to write. Required for write if data is omitted.",
+			},
+			"confirm": map[string]any{
+				"type":        "boolean",
+				"description": "Must be true for write operations.",
+			},
+		},
+		"required": []string{"action"},
+	}
+}
+
+func (t *SerialTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	action, ok := args["action"].(string)
+	if !ok || strings.TrimSpace(action) == "" {
+		return ErrorResult("action is required")
+	}
+
+	switch action {
+	case "list":
+		return t.list()
+	case "read":
+		return t.read(args)
+	case "write":
+		return t.write(args)
+	default:
+		return ErrorResult(fmt.Sprintf("unknown action: %s (valid: list, read, write)", action))
+	}
+}
+
+func (t *SerialTool) list() *ToolResult {
+	ports, err := serialListPorts()
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("failed to list serial ports: %v", err))
+	}
+	if len(ports) == 0 {
+		return SilentResult("No serial ports found on this host.")
+	}
+
+	result, _ := json.MarshalIndent(map[string]any{
+		"ports": ports,
+		"count": len(ports),
+	}, "", "  ")
+	return SilentResult(string(result))
+}
+
+func (t *SerialTool) read(args map[string]any) *ToolResult {
+	cfg, errResult := parseSerialConfig(args)
+	if errResult != nil {
+		return errResult
+	}
+
+	length := 0
+	if v, ok := args["length"].(float64); ok {
+		length = int(v)
+	}
+	if length < 1 || length > maxSerialReadBytes {
+		return ErrorResult(fmt.Sprintf("length is required for read (1-%d)", maxSerialReadBytes))
+	}
+
+	timeout, errResult := parseSerialTimeout(args)
+	if errResult != nil {
+		return errResult
+	}
+
+	data, err := serialRead(cfg, length, timeout)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("serial read failed on %s: %v", cfg.Port, err))
+	}
+
+	return SilentResult(formatSerialPayload("read", cfg, data, timeout))
+}
+
+func (t *SerialTool) write(args map[string]any) *ToolResult {
+	confirm, _ := args["confirm"].(bool)
+	if !confirm {
+		return ErrorResult(
+			"write operations require confirm: true. Please confirm with the user before sending bytes to a serial device.",
+		)
+	}
+
+	cfg, errResult := parseSerialConfig(args)
+	if errResult != nil {
+		return errResult
+	}
+	timeout, errResult := parseSerialTimeout(args)
+	if errResult != nil {
+		return errResult
+	}
+	payload, errResult := parseSerialWritePayload(args)
+	if errResult != nil {
+		return errResult
+	}
+
+	written, err := serialWrite(cfg, payload, timeout)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("serial write failed on %s: %v", cfg.Port, err))
+	}
+
+	result, _ := json.MarshalIndent(map[string]any{
+		"action":     "write",
+		"port":       cfg.Port,
+		"baud":       cfg.Baud,
+		"data_bits":  cfg.DataBits,
+		"parity":     cfg.Parity,
+		"stop_bits":  cfg.StopBits,
+		"timeout_ms": timeout.Milliseconds(),
+		"written":    written,
+		"payload":    serialPayloadSummary(payload),
+	}, "", "  ")
+	return SilentResult(string(result))
+}
+
+func parseSerialConfig(args map[string]any) (serialConfig, *ToolResult) {
+	port, ok := args["port"].(string)
+	port = strings.TrimSpace(port)
+	if !ok || port == "" {
+		return serialConfig{}, ErrorResult("port is required (for example /dev/ttyUSB0, /dev/cu.usbserial-0001, or COM3)")
+	}
+
+	cfg := serialConfig{
+		Port:     port,
+		Baud:     defaultSerialBaud,
+		DataBits: defaultSerialDataBits,
+		Parity:   "none",
+		StopBits: defaultSerialStopBits,
+	}
+
+	if v, ok := args["baud"].(float64); ok {
+		cfg.Baud = int(v)
+	}
+	if cfg.Baud < 50 || cfg.Baud > 4000000 {
+		return serialConfig{}, ErrorResult("baud must be between 50 and 4000000")
+	}
+
+	if v, ok := args["data_bits"].(float64); ok {
+		cfg.DataBits = int(v)
+	}
+	switch cfg.DataBits {
+	case 5, 6, 7, 8:
+	default:
+		return serialConfig{}, ErrorResult("data_bits must be one of 5, 6, 7, or 8")
+	}
+
+	if v, ok := args["parity"].(string); ok && strings.TrimSpace(v) != "" {
+		cfg.Parity = strings.ToLower(strings.TrimSpace(v))
+	}
+	switch cfg.Parity {
+	case "none", "even", "odd":
+	default:
+		return serialConfig{}, ErrorResult(`parity must be one of "none", "even", or "odd"`)
+	}
+
+	if v, ok := args["stop_bits"].(float64); ok {
+		cfg.StopBits = int(v)
+	}
+	if cfg.StopBits != 1 && cfg.StopBits != 2 {
+		return serialConfig{}, ErrorResult("stop_bits must be 1 or 2")
+	}
+
+	return cfg, nil
+}
+
+func parseSerialTimeout(args map[string]any) (time.Duration, *ToolResult) {
+	timeoutMS := defaultSerialTimeoutMS
+	if v, ok := args["timeout_ms"].(float64); ok {
+		timeoutMS = int(v)
+	}
+	if timeoutMS < 1 || timeoutMS > 60000 {
+		return 0, ErrorResult("timeout_ms must be between 1 and 60000")
+	}
+	return time.Duration(timeoutMS) * time.Millisecond, nil
+}
+
+func parseSerialWritePayload(args map[string]any) ([]byte, *ToolResult) {
+	if text, ok := args["text"].(string); ok && text != "" {
+		if !utf8.ValidString(text) {
+			return nil, ErrorResult("text must be valid UTF-8")
+		}
+		if len(text) > maxSerialPayloadBytes {
+			return nil, ErrorResult(fmt.Sprintf("text payload too large: maximum %d bytes", maxSerialPayloadBytes))
+		}
+		return []byte(text), nil
+	}
+
+	dataRaw, ok := args["data"].([]any)
+	if !ok || len(dataRaw) == 0 {
+		return nil, ErrorResult("write requires either text or data")
+	}
+	if len(dataRaw) > maxSerialPayloadBytes {
+		return nil, ErrorResult(fmt.Sprintf("data too long: maximum %d bytes", maxSerialPayloadBytes))
+	}
+
+	data := make([]byte, len(dataRaw))
+	for i, v := range dataRaw {
+		f, ok := v.(float64)
+		if !ok {
+			return nil, ErrorResult(fmt.Sprintf("data[%d] is not a valid byte value", i))
+		}
+		b := int(f)
+		if b < 0 || b > 255 {
+			return nil, ErrorResult(fmt.Sprintf("data[%d] = %d is out of byte range (0-255)", i, b))
+		}
+		data[i] = byte(b)
+	}
+
+	return data, nil
+}
+
+func formatSerialPayload(action string, cfg serialConfig, data []byte, timeout time.Duration) string {
+	result, _ := json.MarshalIndent(map[string]any{
+		"action":     action,
+		"port":       cfg.Port,
+		"baud":       cfg.Baud,
+		"data_bits":  cfg.DataBits,
+		"parity":     cfg.Parity,
+		"stop_bits":  cfg.StopBits,
+		"timeout_ms": timeout.Milliseconds(),
+		"payload":    serialPayloadSummary(data),
+	}, "", "  ")
+	return string(result)
+}
+
+func serialPayloadSummary(data []byte) map[string]any {
+	hexValues := make([]string, len(data))
+	intValues := make([]int, len(data))
+	for i, b := range data {
+		hexValues[i] = fmt.Sprintf("0x%02x", b)
+		intValues[i] = int(b)
+	}
+
+	summary := map[string]any{
+		"length": len(data),
+		"bytes":  intValues,
+		"hex":    hexValues,
+	}
+	if utf8.Valid(data) {
+		summary["text"] = string(data)
+	}
+	return summary
+}

--- a/pkg/tools/serial_darwin.go
+++ b/pkg/tools/serial_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package tools
+
+import "golang.org/x/sys/unix"
+
+func serialGetTermios(fd int) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(fd, unix.TIOCGETA)
+}
+
+func serialSetSpeed(tio *unix.Termios, speed uint32) error {
+	// On darwin (this x/sys version) Termios.Ispeed/Ospeed are uint64.
+	tio.Ispeed = uint64(speed)
+	tio.Ospeed = uint64(speed)
+	return nil
+}
+
+func serialSetTermios(fd int, tio *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TIOCSETA, tio)
+}

--- a/pkg/tools/serial_linux.go
+++ b/pkg/tools/serial_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package tools
+
+import "golang.org/x/sys/unix"
+
+func serialGetTermios(fd int) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(fd, unix.TCGETS)
+}
+
+func serialSetSpeed(tio *unix.Termios, speed uint32) error {
+	tio.Ispeed = speed
+	tio.Ospeed = speed
+	return nil
+}
+
+func serialSetTermios(fd int, tio *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TCSETS, tio)
+}

--- a/pkg/tools/serial_other.go
+++ b/pkg/tools/serial_other.go
@@ -1,0 +1,20 @@
+//go:build !linux && !darwin && !windows
+
+package tools
+
+import (
+	"fmt"
+	"time"
+)
+
+func serialListPorts() ([]serialPortInfo, error) {
+	return nil, nil
+}
+
+func serialRead(cfg serialConfig, length int, timeout time.Duration) ([]byte, error) {
+	return nil, fmt.Errorf("serial is not supported on this platform")
+}
+
+func serialWrite(cfg serialConfig, data []byte, timeout time.Duration) (int, error) {
+	return 0, fmt.Errorf("serial is not supported on this platform")
+}

--- a/pkg/tools/serial_test.go
+++ b/pkg/tools/serial_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSerialConfig(t *testing.T) {
+	cfg, errResult := parseSerialConfig(map[string]any{
+		"port":      "COM3",
+		"baud":      float64(9600),
+		"data_bits": float64(7),
+		"parity":    "even",
+		"stop_bits": float64(2),
+	})
+	if errResult != nil {
+		t.Fatalf("parseSerialConfig() unexpected error = %v", errResult.ForLLM)
+	}
+
+	if cfg.Port != "COM3" || cfg.Baud != 9600 || cfg.DataBits != 7 || cfg.Parity != "even" || cfg.StopBits != 2 {
+		t.Fatalf("parseSerialConfig() = %#v", cfg)
+	}
+}
+
+func TestParseSerialConfigRejectsInvalidParity(t *testing.T) {
+	_, errResult := parseSerialConfig(map[string]any{
+		"port":   "/dev/ttyUSB0",
+		"parity": "mark",
+	})
+	if errResult == nil {
+		t.Fatal("expected invalid parity to fail")
+	}
+}
+
+func TestParseSerialTimeout(t *testing.T) {
+	timeout, errResult := parseSerialTimeout(map[string]any{
+		"timeout_ms": float64(2500),
+	})
+	if errResult != nil {
+		t.Fatalf("parseSerialTimeout() unexpected error = %v", errResult.ForLLM)
+	}
+	if timeout != 2500*time.Millisecond {
+		t.Fatalf("timeout = %v, want 2500ms", timeout)
+	}
+}
+
+func TestParseSerialWritePayloadSupportsText(t *testing.T) {
+	data, errResult := parseSerialWritePayload(map[string]any{
+		"text": "AT\r\n",
+	})
+	if errResult != nil {
+		t.Fatalf("parseSerialWritePayload() unexpected error = %v", errResult.ForLLM)
+	}
+	if string(data) != "AT\r\n" {
+		t.Fatalf("payload = %q, want %q", string(data), "AT\r\n")
+	}
+}
+
+func TestParseSerialWritePayloadRejectsOutOfRangeByte(t *testing.T) {
+	_, errResult := parseSerialWritePayload(map[string]any{
+		"data": []any{float64(256)},
+	})
+	if errResult == nil {
+		t.Fatal("expected payload validation failure")
+	}
+}

--- a/pkg/tools/serial_unix.go
+++ b/pkg/tools/serial_unix.go
@@ -1,0 +1,263 @@
+//go:build linux || darwin
+
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func serialListPorts() ([]serialPortInfo, error) {
+	patterns := []string{
+		"/dev/ttyS*",
+		"/dev/ttyUSB*",
+		"/dev/ttyACM*",
+		"/dev/ttyAMA*",
+		"/dev/rfcomm*",
+		"/dev/tty.*",
+		"/dev/cu.*",
+	}
+
+	seen := make(map[string]struct{})
+	ports := make([]serialPortInfo, 0)
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			if _, ok := seen[match]; ok {
+				continue
+			}
+			info, err := os.Stat(match)
+			if err != nil || info.IsDir() {
+				continue
+			}
+			seen[match] = struct{}{}
+			ports = append(ports, serialPortInfo{
+				Name: filepath.Base(match),
+				Path: match,
+			})
+		}
+	}
+
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Path < ports[j].Path
+	})
+	return ports, nil
+}
+
+func serialRead(cfg serialConfig, length int, timeout time.Duration) ([]byte, error) {
+	fd, err := openAndConfigureSerialPort(cfg)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(fd)
+
+	buf := make([]byte, length)
+	total := 0
+	deadline := time.Now().Add(timeout)
+
+	for total < length {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+
+		n, err := pollRead(fd, buf[total:], remaining)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			break
+		}
+		total += n
+	}
+
+	return buf[:total], nil
+}
+
+func serialWrite(cfg serialConfig, data []byte, timeout time.Duration) (int, error) {
+	fd, err := openAndConfigureSerialPort(cfg)
+	if err != nil {
+		return 0, err
+	}
+	defer unix.Close(fd)
+
+	total := 0
+	deadline := time.Now().Add(timeout)
+	for total < len(data) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return total, fmt.Errorf("timeout while writing serial data")
+		}
+
+		n, err := pollWrite(fd, data[total:], remaining)
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, fmt.Errorf("serial port accepted zero bytes")
+		}
+		total += n
+	}
+
+	return total, nil
+}
+
+func openAndConfigureSerialPort(cfg serialConfig) (int, error) {
+	fd, err := unix.Open(normalizeUnixSerialPath(cfg.Port), unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return -1, err
+	}
+
+	if err := unix.SetNonblock(fd, false); err != nil {
+		unix.Close(fd)
+		return -1, err
+	}
+
+	if err := configureUnixSerialPort(fd, cfg); err != nil {
+		unix.Close(fd)
+		return -1, err
+	}
+
+	return fd, nil
+}
+
+func configureUnixSerialPort(fd int, cfg serialConfig) error {
+	tio, err := serialGetTermios(fd)
+	if err != nil {
+		return err
+	}
+
+	tio.Iflag = 0
+	tio.Oflag = 0
+	tio.Lflag = 0
+	tio.Cflag = unix.CREAD | unix.CLOCAL
+	tio.Cc[unix.VMIN] = 0
+	tio.Cc[unix.VTIME] = 0
+
+	switch cfg.DataBits {
+	case 5:
+		tio.Cflag |= unix.CS5
+	case 6:
+		tio.Cflag |= unix.CS6
+	case 7:
+		tio.Cflag |= unix.CS7
+	default:
+		tio.Cflag |= unix.CS8
+	}
+
+	switch cfg.Parity {
+	case "even":
+		tio.Cflag |= unix.PARENB
+	case "odd":
+		tio.Cflag |= unix.PARENB | unix.PARODD
+	}
+
+	if cfg.StopBits == 2 {
+		tio.Cflag |= unix.CSTOPB
+	}
+
+	speed, err := serialBaudToUnix(cfg.Baud)
+	if err != nil {
+		return err
+	}
+	if err := serialSetSpeed(tio, speed); err != nil {
+		return err
+	}
+
+	return serialSetTermios(fd, tio)
+}
+
+func serialBaudToUnix(baud int) (uint32, error) {
+	switch baud {
+	case 50:
+		return unix.B50, nil
+	case 75:
+		return unix.B75, nil
+	case 110:
+		return unix.B110, nil
+	case 134:
+		return unix.B134, nil
+	case 150:
+		return unix.B150, nil
+	case 200:
+		return unix.B200, nil
+	case 300:
+		return unix.B300, nil
+	case 600:
+		return unix.B600, nil
+	case 1200:
+		return unix.B1200, nil
+	case 1800:
+		return unix.B1800, nil
+	case 2400:
+		return unix.B2400, nil
+	case 4800:
+		return unix.B4800, nil
+	case 9600:
+		return unix.B9600, nil
+	case 19200:
+		return unix.B19200, nil
+	case 38400:
+		return unix.B38400, nil
+	case 57600:
+		return unix.B57600, nil
+	case 115200:
+		return unix.B115200, nil
+	case 230400:
+		return unix.B230400, nil
+	default:
+		return 0, fmt.Errorf("unsupported baud rate on this platform: %d", baud)
+	}
+}
+
+func pollRead(fd int, dst []byte, timeout time.Duration) (int, error) {
+	pfd := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	n, err := unix.Poll(pfd, durationToPollTimeout(timeout))
+	if err != nil {
+		return 0, err
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	return unix.Read(fd, dst)
+}
+
+func pollWrite(fd int, src []byte, timeout time.Duration) (int, error) {
+	pfd := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}
+	n, err := unix.Poll(pfd, durationToPollTimeout(timeout))
+	if err != nil {
+		return 0, err
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	return unix.Write(fd, src)
+}
+
+func durationToPollTimeout(timeout time.Duration) int {
+	if timeout <= 0 {
+		return 0
+	}
+	ms := int(timeout / time.Millisecond)
+	if ms == 0 {
+		return 1
+	}
+	return ms
+}
+
+func normalizeUnixSerialPath(port string) string {
+	trimmed := strings.TrimSpace(port)
+	if strings.HasPrefix(trimmed, "/dev/") {
+		return trimmed
+	}
+	return "/dev/" + trimmed
+}

--- a/pkg/tools/serial_windows.go
+++ b/pkg/tools/serial_windows.go
@@ -1,0 +1,214 @@
+//go:build windows
+
+package tools
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+var (
+	kernel32            = windows.NewLazySystemDLL("kernel32.dll")
+	procGetCommState    = kernel32.NewProc("GetCommState")
+	procSetCommState    = kernel32.NewProc("SetCommState")
+	procSetCommTimeouts = kernel32.NewProc("SetCommTimeouts")
+	procPurgeComm       = kernel32.NewProc("PurgeComm")
+)
+
+const (
+	purgeTxClear = 0x0004
+	purgeRxClear = 0x0008
+)
+
+type dcb struct {
+	DCBlength  uint32
+	BaudRate   uint32
+	Flags      uint32
+	Reserved   uint16
+	XonLim     uint16
+	XoffLim    uint16
+	ByteSize   byte
+	Parity     byte
+	StopBits   byte
+	XonChar    byte
+	XoffChar   byte
+	ErrorChar  byte
+	EofChar    byte
+	EvtChar    byte
+	wReserved1 uint16
+}
+
+type commTimeouts struct {
+	ReadIntervalTimeout         uint32
+	ReadTotalTimeoutMultiplier  uint32
+	ReadTotalTimeoutConstant    uint32
+	WriteTotalTimeoutMultiplier uint32
+	WriteTotalTimeoutConstant   uint32
+}
+
+func serialListPorts() ([]serialPortInfo, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DEVICEMAP\SERIALCOMM`, registry.QUERY_VALUE)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer key.Close()
+
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	ports := make([]serialPortInfo, 0, len(names))
+	seen := make(map[string]struct{})
+	for _, name := range names {
+		value, _, err := key.GetStringValue(name)
+		if err != nil {
+			continue
+		}
+		portName := strings.TrimSpace(value)
+		if portName == "" {
+			continue
+		}
+		normalized := strings.ToUpper(portName)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		ports = append(ports, serialPortInfo{
+			Name: normalized,
+			Path: normalized,
+		})
+	}
+
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Path < ports[j].Path
+	})
+	return ports, nil
+}
+
+func serialRead(cfg serialConfig, length int, timeout time.Duration) ([]byte, error) {
+	handle, err := openAndConfigureWindowsSerial(cfg, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(handle)
+
+	buf := make([]byte, length)
+	var read uint32
+	if err := windows.ReadFile(handle, buf, &read, nil); err != nil {
+		return nil, err
+	}
+	return buf[:read], nil
+}
+
+func serialWrite(cfg serialConfig, data []byte, timeout time.Duration) (int, error) {
+	handle, err := openAndConfigureWindowsSerial(cfg, timeout)
+	if err != nil {
+		return 0, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var written uint32
+	if err := windows.WriteFile(handle, data, &written, nil); err != nil {
+		return int(written), err
+	}
+	return int(written), nil
+}
+
+func openAndConfigureWindowsSerial(cfg serialConfig, timeout time.Duration) (windows.Handle, error) {
+	path := normalizeWindowsSerialPath(cfg.Port)
+	handle, err := windows.CreateFile(
+		windows.StringToUTF16Ptr(path),
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		0,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := configureWindowsSerialPort(handle, cfg, timeout); err != nil {
+		windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func configureWindowsSerialPort(handle windows.Handle, cfg serialConfig, timeout time.Duration) error {
+	state := dcb{DCBlength: uint32(unsafe.Sizeof(dcb{}))}
+	r1, _, err := procGetCommState.Call(uintptr(handle), uintptr(unsafe.Pointer(&state)))
+	if r1 == 0 {
+		return err
+	}
+
+	state.BaudRate = uint32(cfg.Baud)
+	state.ByteSize = byte(cfg.DataBits)
+	state.Flags |= 0x00000001 // fBinary
+
+	switch cfg.Parity {
+	case "even":
+		state.Parity = 2
+		state.Flags |= 0x00000002 // fParity
+	case "odd":
+		state.Parity = 1
+		state.Flags |= 0x00000002 // fParity
+	default:
+		state.Parity = 0
+		state.Flags &^= 0x00000002
+	}
+
+	switch cfg.StopBits {
+	case 2:
+		state.StopBits = 2
+	default:
+		state.StopBits = 0
+	}
+
+	r1, _, err = procSetCommState.Call(uintptr(handle), uintptr(unsafe.Pointer(&state)))
+	if r1 == 0 {
+		return err
+	}
+
+	timeoutMS := uint32(timeout / time.Millisecond)
+	if timeoutMS == 0 {
+		timeoutMS = 1
+	}
+	timeouts := commTimeouts{
+		ReadIntervalTimeout:         timeoutMS,
+		ReadTotalTimeoutConstant:    timeoutMS,
+		WriteTotalTimeoutConstant:   timeoutMS,
+		ReadTotalTimeoutMultiplier:  0,
+		WriteTotalTimeoutMultiplier: 0,
+	}
+	r1, _, err = procSetCommTimeouts.Call(uintptr(handle), uintptr(unsafe.Pointer(&timeouts)))
+	if r1 == 0 {
+		return err
+	}
+
+	procPurgeComm.Call(uintptr(handle), uintptr(purgeRxClear|purgeTxClear))
+	return nil
+}
+
+func normalizeWindowsSerialPath(port string) string {
+	trimmed := strings.ToUpper(strings.TrimSpace(port))
+	if strings.HasPrefix(trimmed, `\\.\`) {
+		return trimmed
+	}
+	if filepath.VolumeName(trimmed) != "" {
+		return trimmed
+	}
+	return `\\.\` + trimmed
+}

--- a/scripts/coverage-exclude.txt
+++ b/scripts/coverage-exclude.txt
@@ -9,6 +9,12 @@ pkg/tools/i2c_other.go
 pkg/tools/spi.go
 pkg/tools/spi_linux.go
 pkg/tools/spi_other.go
+pkg/tools/serial.go
+pkg/tools/serial_darwin.go
+pkg/tools/serial_linux.go
+pkg/tools/serial_unix.go
+pkg/tools/serial_windows.go
+pkg/tools/serial_other.go
 
 # OS-specific process shims (platform dispatch; logic is in cross-platform files)
 pkg/tools/shell_process_unix.go

--- a/web/backend/api/config.go
+++ b/web/backend/api/config.go
@@ -17,7 +17,24 @@ func (h *Handler) registerConfigRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/config", h.handleGetConfig)
 	mux.HandleFunc("PUT /api/config", h.handleUpdateConfig)
 	mux.HandleFunc("PATCH /api/config", h.handlePatchConfig)
+	mux.HandleFunc("POST /api/config/reset", h.handleResetConfig)
 	mux.HandleFunc("POST /api/config/test-command-patterns", h.handleTestCommandPatterns)
+}
+
+// handleResetConfig resets the configuration to factory defaults. Security
+// credentials (API keys, channel secrets) are preserved and a timestamped
+// backup is taken first. Changes apply on the next gateway (re)start, matching
+// handleUpdateConfig behaviour. Port of upstream picoclaw f53222f6a.
+//
+//	POST /api/config/reset
+func (h *Handler) handleResetConfig(w http.ResponseWriter, r *http.Request) {
+	if err := config.ResetToDefaults(h.configPath); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to reset config: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // handleGetConfig returns the complete system configuration.

--- a/workspace/skills/agent-browser/SKILL.md
+++ b/workspace/skills/agent-browser/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: agent-browser
+description: "Browser automation via agent-browser CLI. Use when the user needs to navigate websites, fill forms, click buttons, take screenshots, extract data, or test web apps."
+metadata: {"nanobot":{"emoji":"🌐","requires":{"bins":["agent-browser"]},"install":[{"id":"npm","kind":"npm","package":"agent-browser","global":true,"bins":["agent-browser"],"label":"Install agent-browser (npm)"}]}}
+---
+
+# Agent Browser
+
+CLI browser automation via Chrome/Chromium CDP. Install: `npm i -g agent-browser && agent-browser install`.
+
+**Before using this skill**, verify the tool is available by running `which agent-browser`. If the command is not found, tell the user that browser automation requires the `agent-browser` CLI and Chromium, which are only available in the heavy container image. Do not attempt to install it at runtime.
+
+## Core Workflow
+
+1. `agent-browser open <url>` — navigate
+2. `agent-browser snapshot -i` — get interactive elements with refs (`@e1`, `@e2`, ...)
+3. Interact using refs — `click @e1`, `fill @e2 "text"`
+4. Re-snapshot after any navigation or DOM change — refs are invalidated
+
+```bash
+agent-browser open https://example.com/form
+agent-browser snapshot -i
+# @e1 [input] "Email", @e2 [input] "Password", @e3 [button] "Submit"
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "secret"
+agent-browser click @e3
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+Chain commands with `&&` when you don't need intermediate output:
+```bash
+agent-browser open https://example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+```
+
+## Commands
+
+```bash
+# Navigation
+agent-browser open <url>
+agent-browser close
+
+# Snapshot
+agent-browser snapshot -i                # Interactive elements with refs
+agent-browser snapshot -s "#selector"    # Scope to CSS selector
+
+# Interaction (use @refs from snapshot)
+agent-browser click @e1
+agent-browser fill @e2 "text"            # Clear + type
+agent-browser type @e2 "text"            # Type without clearing
+agent-browser select @e1 "option"
+agent-browser check @e1
+agent-browser press Enter
+agent-browser scroll down 500
+
+# Get info
+agent-browser get text @e1
+agent-browser get url
+agent-browser get title
+
+# Wait
+agent-browser wait @e1                   # Wait for element
+agent-browser wait --load networkidle    # Wait for network idle
+agent-browser wait --url "**/dashboard"  # Wait for URL pattern
+agent-browser wait --text "Welcome"      # Wait for text
+agent-browser wait 2000                  # Wait ms
+
+# Capture
+agent-browser screenshot                 # Screenshot to temp dir
+agent-browser screenshot --full          # Full page
+agent-browser screenshot --annotate      # With numbered element labels ([N] -> @eN)
+agent-browser pdf output.pdf
+
+# Semantic locators (when refs unavailable)
+agent-browser find text "Sign In" click
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find role button click --name "Submit"
+```
+
+## Authentication
+
+```bash
+# Option 1: Import from user's running Chrome
+agent-browser --auto-connect state save ./auth.json
+agent-browser --state ./auth.json open https://app.example.com
+
+# Option 2: Persistent profile
+agent-browser --profile ~/.myapp open https://app.example.com/login
+# ... login once, all future runs are authenticated
+
+# Option 3: Session name (auto-save/restore)
+agent-browser --session-name myapp open https://app.example.com/login
+# ... login, close, next run state is restored
+
+# Option 4: State file
+agent-browser state save auth.json
+agent-browser state load auth.json
+```
+
+## Iframes
+
+Iframe content is inlined in snapshots. Interact with iframe refs directly — no frame switch needed.
+
+## Parallel Sessions
+
+```bash
+agent-browser --session s1 open https://site-a.com
+agent-browser --session s2 open https://site-b.com
+agent-browser session list
+```
+
+## JavaScript Eval
+
+```bash
+agent-browser eval 'document.title'
+
+# Complex JS — use --stdin to avoid shell quoting issues
+agent-browser eval --stdin <<'EVALEOF'
+JSON.stringify(Array.from(document.querySelectorAll("a")).map(a => a.href))
+EVALEOF
+```
+
+## Cleanup
+
+Always close sessions when done:
+```bash
+agent-browser close
+agent-browser --session s1 close
+```


### PR DESCRIPTION
## Summary

Syncs beneficial, low-conflict fixes from upstream `sipeed/picoclaw` **v0.2.9** into our fork. From 1107 upstream commits behind, these were curated by file-overlap triage (conflict-risk first), reviewed, and each ported with build/test verification. Tracking docs: `docs/upstream-sync-v0.2.9.md` (+ progress log).

## Functional ports (10)

**Channels**
- `fix(feishu)` invalidate cached token on auth error 99991663 — fixes ~2h auth lockout
- `fix(feishu)` skip empty `random_reaction_emoji` entries (avoids API 231001)
- `fix(feishu)` enrich reply context for card/file replies
- `fix(dingtalk)` honor mention-only groups, strip leading @mentions
- `fix(telegram)` preserve raw OAuth links in HTML rendering (placeholder-based parser reimplementation + 11-case upstream test suite)

**Core / tools / config**
- `fix(cron)` independent session per job execution (prevents history bleed across scheduled runs — important for our trading cron)
- `feat(config)` `ResetToDefaults` + `POST /api/config/reset` (factory reset preserving credentials, with backup + test)
- `feat(tools)` cross-platform serial hardware tool (relocated into our flat `pkg/tools`; hardware driver files added to the Tier 3 coverage exclusion list, matching the i2c/spi precedent)

## Also included
- `test(agent)` behavioral **characterization suite** (9 seam-level tests through `ProcessDirect`) — locks core turn-loop behavior (tool round-trip, session continuity, iteration cap, cancellation, …) as a guard for future upstream syncs.
- `docs/adr-agent-core-convergence.md` — strategy + measurements for converging the agent core onto upstream long-term (foundation lands in a follow-up PR).

## Verification
- `go build ./...` green.
- Per-package tests pass for every touched package (feishu, dingtalk, telegram, cron, config, tools, agent).
- Tier 1 weighted coverage **78.1%** — at parity with `main` (pre-existing; not regressed by this PR).

## Excluded by design
`build(deps)` (Dependabot), provider fixes needing absent providers (gemini/bedrock — AWS SDK footprint), frontend items our rewritten `web/` already handles, and the agent-pipeline refactor (its own initiative — see ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
