### PR TITLE
fix(deps): bump Go to 1.25.13 for 6 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cryptoquantumwave/khunquant
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## What this adds

Bumps the `go` directive in `go.mod` from 1.25.12 to 1.25.13. One line, no source changes.

## Why — our CI security gate is currently red

`govulncheck` is a required check per CLAUDE.md, and it is **failing on `main` today**. Six Go
standard-library advisories have live call traces into our code:

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-6218, GO-2026-6090, GO-2026-6089 | `net/http` | `pkg/auth/oauth.go`, `pkg/health/server.go`, `pkg/mcp/manager.go` |
| GO-2026-6088 | `encoding/xml` | `pkg/channels/wecom/app.go` (`handleMessageCallback` → `xml.Unmarshal`) |
| GO-2026-5972 | `encoding/asn1` | `pkg/channels/irc/irc.go` (TLS connect → `asn1.Unmarshal`) |
| GO-2026-5026 | x/net idna | `pkg/tools/web.go`, `web/backend/api/gateway.go` |

All six are fixed in go1.25.13.

## Safety-relevant properties

Toolchain-only change. No behavioural change to our code, no dependency graph change, no API surface
change. Lowest-risk item in the upstream-sync wave, and it unblocks the security gate for the other PRs.

## How it was tested

Verified independently of the authoring agent:

```
# before, on main (go 1.25.12)
GOTOOLCHAIN=go1.25.12 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -C . -format text ./...
→ exit 3, 6 vulnerabilities affecting our code

# after, on this branch (go 1.25.13)
GOTOOLCHAIN=go1.25.13 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -C . -format text ./...
→ exit 0, "No vulnerabilities found."
```

Also green: `go generate ./...`, `go build ./...`, `go test ./...`, and
`golangci-lint v2.10.1` (0 issues). Verified again after merging all four wave-1 branches together:
6154 tests pass, lint 0, govulncheck exit 0.

## Known limitations

Reproducing the "before" state requires setting `GOTOOLCHAIN` explicitly — a bare
`go run govulncheck` builds the tool with go1.24.1 in some local setups and dies with
"package requires newer Go version" rather than reporting vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)