### PR TITLE
fix(tools): harden exec guard against PowerShell encoding bypass and related gaps

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -336,6 +336,7 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		}
 
 		args := map[string]any{
+			"action":    "run",
 			"command":   job.Payload.Command,
 			"__channel": channel,
 			"__chat_id": chatID,

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -374,6 +374,31 @@ func TestCronTool_ExecuteJobDeliverMessageDirectlyToBus(t *testing.T) {
 	}
 }
 
+func TestCronTool_ExecuteJobRunsCommand(t *testing.T) {
+	tool := newTestCronToolWithConfig(t, config.DefaultConfig())
+	job := &cron.CronJob{}
+	job.Payload.Channel = "cli"
+	job.Payload.To = "direct"
+	job.Payload.Command = "echo cron-test-ok"
+
+	if got := tool.ExecuteJob(context.Background(), job); got != "ok" {
+		t.Fatalf("ExecuteJob() = %q, want ok", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var msg bus.OutboundMessage
+	select {
+	case msg = <-tool.msgBus.OutboundChan():
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for outbound message")
+	}
+	if !strings.Contains(msg.Content, "cron-test-ok") {
+		t.Fatalf("expected command output containing 'cron-test-ok', got: %s", msg.Content)
+	}
+}
+
 func TestCronTool_ExecuteJobReturnsErrorWithoutPublish(t *testing.T) {
 	executor := &stubJobExecutor{
 		response: "this response must not be published",

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
 	"github.com/cryptoquantumwave/khunquant/pkg/constants"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 )
 
 type ExecTool struct {
@@ -313,6 +315,16 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *ToolResult
 
 	done := make(chan error, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.ErrorCF("shell", "cmd.Wait goroutine panic recovered",
+					map[string]any{
+						"panic": fmt.Sprintf("%v", r),
+						"stack": string(debug.Stack()),
+					})
+				done <- fmt.Errorf("panic in cmd.Wait: %v", r)
+			}
+		}()
 		done <- cmd.Wait()
 	}()
 

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -81,6 +81,26 @@ var (
 		regexp.MustCompile(`\bls\s+/(?:\s|$)`),   // ls / - list root directory
 	}
 
+	// windowsDenyPatterns contains PowerShell-specific deny patterns that only
+	// apply on Windows, where commands are executed via powershell -Command.
+	windowsDenyPatterns = []*regexp.Regexp{
+		// [Text.Encoding] used to construct command strings at runtime.
+		// Matches [Text.Encoding] and [System.Text.Encoding] variants.
+		regexp.MustCompile(`\[(?:\w+\.)?text\.encoding\]`),
+		// PowerShell -EncodedCommand flag (base64-encoded command) and all short forms.
+		// Matches: -e, -ec, -enc, -en, -EncodedCommand (all with space prefix)
+		regexp.MustCompile(` -e(?:$|\s)| -ec(?:$|\s)| -enc(?:$|\s)| -en(?:$|\s)| -encodedcommand\b`),
+		// .GetString called on byte array to decode commands.
+		regexp.MustCompile(`\.getstring\s*\(\s*\[byte\[\]`),
+		// FromBase64String used in command construction chain.
+		regexp.MustCompile(`frombase64string\(`),
+		// PowerShell variable holding byte array used in GetString.
+		regexp.MustCompile(`\$[a-zA-Z_]\w*\s*=\s*\[byte\[\]`),
+		// Unicode escape sequences that could be used to construct commands.
+		// Matches \uXXXX format used to represent characters like i = "i"
+		regexp.MustCompile(`\\u[0-9a-fA-F]{4}`),
+	}
+
 	// absolutePathPattern matches absolute file paths in commands (Unix and Windows).
 	absolutePathPattern = regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/(?:[^\s\"']*)?`)
 
@@ -122,6 +142,9 @@ func NewExecToolWithConfig(
 		allowRemote = execConfig.AllowRemote
 		if enableDenyPatterns {
 			denyPatterns = append(denyPatterns, defaultDenyPatterns...)
+			if runtime.GOOS == "windows" {
+				denyPatterns = append(denyPatterns, windowsDenyPatterns...)
+			}
 			if len(execConfig.CustomDenyPatterns) > 0 {
 				fmt.Printf("Using custom deny patterns: %v\n", execConfig.CustomDenyPatterns)
 				for _, pattern := range execConfig.CustomDenyPatterns {
@@ -145,6 +168,9 @@ func NewExecToolWithConfig(
 		}
 	} else {
 		denyPatterns = append(denyPatterns, defaultDenyPatterns...)
+		if runtime.GOOS == "windows" {
+			denyPatterns = append(denyPatterns, windowsDenyPatterns...)
+		}
 	}
 
 	timeout := 60 * time.Second
@@ -363,6 +389,30 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *ToolResult
 	}
 }
 
+// expandPowerShellEnvVars expands environment variable syntax used by both
+// PowerShell ($env:VAR) and CMD (%VAR%) to their actual values.
+func expandPowerShellEnvVars(cmd string) string {
+	// Handle PowerShell style: $env:VAR and ${env:VAR}
+	rePs := regexp.MustCompile(`\$\{?env:(\w+)\}?`)
+	cmd = rePs.ReplaceAllStringFunc(cmd, func(match string) string {
+		varName := rePs.FindStringSubmatch(match)[1]
+		if val := os.Getenv(varName); val != "" {
+			return val
+		}
+		return match
+	})
+
+	// Handle CMD style: %VAR%
+	reCmd := regexp.MustCompile(`%([^%]+)%`)
+	return reCmd.ReplaceAllStringFunc(cmd, func(match string) string {
+		varName := reCmd.FindStringSubmatch(match)[1]
+		if val := os.Getenv(varName); val != "" {
+			return val
+		}
+		return match
+	})
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
@@ -398,13 +448,24 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 	}
 
 	if t.restrictToWorkspace {
-		if strings.Contains(cmd, "..\\") || strings.Contains(cmd, "../") {
+		// Block path traversal patterns including .../.../ variants
+		if regexp.MustCompile(`\.\.(?:[\\/]\.\.)*[\\/]`).MatchString(cmd) {
 			return "Command blocked by safety guard (path traversal detected)"
 		}
 
 		cwdPath, err := filepath.Abs(cwd)
 		if err != nil {
 			return ""
+		}
+
+		// On Windows, expand ~ and PowerShell environment variables ($env:VAR) before path checking
+		if runtime.GOOS == "windows" {
+			// Expand PowerShell environment variables ($env:VAR and ${env:VAR})
+			cmd = expandPowerShellEnvVars(cmd)
+			// Also expand ~ for completeness
+			if home, err := os.UserHomeDir(); err == nil {
+				cmd = strings.ReplaceAll(cmd, "~", filepath.FromSlash(home))
+			}
 		}
 
 		// Web URL schemes whose path components (starting with //) should be exempt
@@ -441,6 +502,22 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 			p, err := filepath.Abs(raw)
 			if err != nil {
 				continue
+			}
+
+			// Windows-specific: normalize paths to block ADS and extended-length paths
+			if runtime.GOOS == "windows" {
+				// Strip \\?\ prefix (extended-length path)
+				p = strings.TrimPrefix(p, `\\?\`)
+				// Strip NTFS alternate data streams (only if colon is not at position 1 = drive letter)
+				if idx := strings.Index(p, ":"); idx > 1 {
+					p = p[:idx]
+				}
+			}
+
+			// Check symlinks and junctions
+			resolved, err := filepath.EvalSymlinks(p)
+			if err == nil {
+				p = resolved
 			}
 
 			if safePaths[p] {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -489,6 +489,59 @@ func isShellTokenBoundary(b byte) bool {
 	return false
 }
 
+// looksLikeDomain returns true when s looks like a DNS domain name:
+// it contains at least one dot, starts with an alphanumeric character,
+// and does not end with a common file extension.
+func looksLikeDomain(s string) bool {
+	if len(s) < 3 || !strings.ContainsRune(s, '.') {
+		return false
+	}
+	first := s[0]
+	if !((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || (first >= '0' && first <= '9')) {
+		return false
+	}
+	// Exclude tokens ending with common file/programming extensions,
+	// e.g. "script.py", "main.go", "app.exe".
+	if idx := strings.LastIndexByte(s, '.'); idx >= 0 {
+		ext := strings.ToLower(s[idx+1:])
+		if commonFileExtension(ext) {
+			return false
+		}
+	}
+	return true
+}
+
+// commonFileExtension returns true when ext is a file extension that
+// strongly indicates a local file rather than a domain TLD.
+func commonFileExtension(ext string) bool {
+	switch ext {
+	case "py", "js", "ts", "tsx", "jsx", "go", "rs", "rb", "php",
+		"java", "c", "cpp", "h", "hpp", "cs", "swift", "kt", "scala",
+		"sh", "bash", "zsh", "fish", "ps1", "bat", "cmd",
+		"txt", "md", "rst", "log", "json", "yaml", "yml", "toml",
+		"xml", "html", "css", "scss", "ini", "cfg", "conf", "env",
+		"exe", "dll", "so", "dylib", "lib", "a", "o", "obj",
+		"zip", "tar", "gz", "bz2", "xz", "7z", "rar",
+		"png", "jpg", "jpeg", "gif", "svg", "ico", "bmp", "webp",
+		"mp3", "mp4", "wav", "avi", "mov", "mkv", "flac",
+		"pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
+		"pub", "pem", "key", "crt", "cer", "p12", "pfx",
+		"bak", "tmp", "swp", "lock",
+		"ttf", "otf", "woff", "woff2", "eot",
+		"deb", "rpm", "apk", "msi", "dmg",
+		"sql", "sqlite", "db":
+		return true
+	}
+	return false
+}
+
+// localPathExists returns true when the given token resolves to an
+// existing filesystem entry relative to cwd.
+func localPathExists(cwd, token string) bool {
+	info, err := os.Lstat(filepath.Join(cwd, token))
+	return err == nil && info != nil
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
@@ -576,6 +629,27 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 				}
 
 				if isWebURL {
+					continue
+				}
+			}
+
+			// Skip scheme-less URL paths like "wttr.in/Beijing".
+			// When a /path is immediately preceded by a token that looks
+			// like a domain name and that token does NOT exist as a local
+			// filesystem entry, treat the path as part of a URL and skip
+			// workspace sandbox validation.
+			//
+			// The local-path-exists guard prevents symlink bypass: if
+			// "foo.bar" exists as a local symlink or directory, the path
+			// still undergoes full workspace validation (see #2965).
+			if loc[0] > 0 && raw[0] == '/' {
+				// Find the token immediately before the "/".
+				j := loc[0] - 1
+				for j >= 0 && !isShellTokenBoundary(cmd[j]) {
+					j--
+				}
+				token := cmd[j+1 : loc[0]]
+				if looksLikeDomain(token) && !localPathExists(cwd, token) {
 					continue
 				}
 			}

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -413,6 +413,82 @@ func expandPowerShellEnvVars(cmd string) string {
 	})
 }
 
+// commandPathAbs resolves a command path to an absolute path, accounting for
+// relative paths within the workspace.
+func commandPathAbs(pathText, cwdPath string) (string, error) {
+	if filepath.IsAbs(pathText) {
+		return filepath.Abs(pathText)
+	}
+	return filepath.Abs(filepath.Join(cwdPath, pathText))
+}
+
+// commandPathTextFromMatch extracts the actual path text from a regex match,
+// handling special cases like relative paths with slashes and option values.
+func commandPathTextFromMatch(cmd string, start, end int) string {
+	raw := cmd[start:end]
+	if !strings.HasPrefix(raw, "/") || isUnixAbsolutePathMatchStart(cmd, start) {
+		return raw
+	}
+
+	tokenStart, tokenEnd := shellTokenBounds(cmd, start)
+	prefix := cmd[tokenStart:start]
+	// For --flag=rel/path, validate the value. For ambiguous attached option
+	// forms like -isystem/path, keep the slash-starting path conservative.
+	if eq := strings.IndexByte(prefix, '='); eq >= 0 {
+		return cmd[tokenStart+eq+1 : tokenEnd]
+	}
+	if strings.HasPrefix(prefix, "-") {
+		return raw
+	}
+	return cmd[tokenStart:tokenEnd]
+}
+
+// shellTokenBounds returns the start and end position of the shell token
+// containing the given index.
+func shellTokenBounds(cmd string, idx int) (int, int) {
+	start := idx
+	for start > 0 && !isShellTokenBoundary(cmd[start-1]) {
+		start--
+	}
+	end := idx
+	for end < len(cmd) && !isShellTokenBoundary(cmd[end]) {
+		end++
+	}
+	return start, end
+}
+
+// isUnixAbsolutePathMatchStart returns true when a regex match beginning with
+// "/" is actually an absolute path token, not the separator inside a relative
+// path such as "skills/foo.py".
+func isUnixAbsolutePathMatchStart(cmd string, idx int) bool {
+	if idx <= 0 {
+		return true
+	}
+
+	prev := cmd[idx-1]
+	if isShellTokenBoundary(prev) || prev == '=' || prev == ',' || prev == '(' || prev == '[' || prev == '{' {
+		return true
+	}
+
+	j := idx - 1
+	for j >= 0 && !isShellTokenBoundary(cmd[j]) {
+		j--
+	}
+	prefix := cmd[j+1 : idx]
+
+	return strings.HasPrefix(prefix, "-") && !strings.Contains(prefix, "=")
+}
+
+// isShellTokenBoundary returns true when b is a byte that separates
+// tokens in a shell command (space, tab, colon, semicolon, pipe, etc.).
+func isShellTokenBoundary(b byte) bool {
+	switch b {
+	case ' ', '\t', ':', ';', '|', '&', '<', '>', '\'', '"', '`', '\n', '\r':
+		return true
+	}
+	return false
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
@@ -458,6 +534,11 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 			return ""
 		}
 
+		// Resolve symlinks on the workspace path to enable proper comparison
+		if resolved, err := filepath.EvalSymlinks(cwdPath); err == nil {
+			cwdPath = resolved
+		}
+
 		// On Windows, expand ~ and PowerShell environment variables ($env:VAR) before path checking
 		if runtime.GOOS == "windows" {
 			// Expand PowerShell environment variables ($env:VAR and ${env:VAR})
@@ -499,7 +580,7 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 				}
 			}
 
-			p, err := filepath.Abs(raw)
+			p, err := commandPathAbs(commandPathTextFromMatch(cmd, loc[0], loc[1]), cwdPath)
 			if err != nil {
 				continue
 			}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -940,3 +940,87 @@ func TestNewExecToolWithConfig_InvalidCustomAllowPattern(t *testing.T) {
 		t.Fatal("expected error for invalid custom allow pattern")
 	}
 }
+
+// TestPowerShellEncodingBypass verifies that PowerShell encoding bypass patterns are blocked.
+func TestPowerShellEncodingBypass(t *testing.T) {
+	// Test the windowsDenyPatterns directly to ensure they're initialized correctly.
+	// Each pattern should match the corresponding encoding bypass attempt.
+	testCases := []struct {
+		name    string
+		pattern int // index into windowsDenyPatterns
+		payload string
+		should  bool // true if it should match (be blocked)
+	}{
+		// [Text.Encoding] variants
+		{name: "Text.Encoding uppercase", pattern: 0, payload: "[Text.Encoding]::UTF8.GetString([byte[]](0x72,0x6d))", should: true},
+		{name: "System.Text.Encoding", pattern: 0, payload: "[System.Text.Encoding]::UTF8.GetString([byte[]](0x72,0x6d))", should: true},
+		// -EncodedCommand forms
+		{name: "-e flag", pattern: 1, payload: "powershell -e JABFAHIAcgBvAHIA", should: true},
+		{name: "-ec flag", pattern: 1, payload: "powershell -ec JABFAHIAcgBvAHIA", should: true},
+		{name: "-enc flag", pattern: 1, payload: "powershell -enc JABFAHIAcgBvAHIA", should: true},
+		{name: "-en flag", pattern: 1, payload: "powershell -en JABFAHIAcgBvAHIA", should: true},
+		{name: "-EncodedCommand flag", pattern: 1, payload: "powershell -EncodedCommand JABFAHIAcgBvAHIA", should: true},
+		// .GetString([byte[]])
+		{name: "GetString byte array", pattern: 2, payload: ".GetString([byte[]](0x61,0x62))", should: true},
+		// FromBase64String
+		{name: "FromBase64String", pattern: 3, payload: "[System.Convert]::FromBase64String('aGVsbG8=')", should: true},
+		// $var=[byte[]]
+		{name: "var assignment to byte array", pattern: 4, payload: "$payload = [byte[]]@(0x72,0x6d)", should: true},
+		// Unicode escapes
+		{name: "unicode escape \\u0041", pattern: 5, payload: "echo \\u0041", should: true},
+		{name: "unicode escape \\u0072", pattern: 5, payload: "powershell -Command \\u0072\\u006d", should: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.pattern >= len(windowsDenyPatterns) {
+				t.Skipf("pattern index %d out of range", tc.pattern)
+			}
+			pattern := windowsDenyPatterns[tc.pattern]
+			matches := pattern.MatchString(strings.ToLower(tc.payload))
+			if matches != tc.should {
+				t.Errorf("pattern %d: expected match=%v, got %v for %q",
+					tc.pattern, tc.should, matches, tc.payload)
+			}
+		})
+	}
+}
+
+// TestPathTraversalVariants verifies that .../.../ and similar variants are blocked.
+func TestPathTraversalVariants(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	ctx := context.Background()
+
+	// Path traversal variants should be blocked
+	blockedCommands := []string{
+		"ls .../.../",
+		"ls ..../..../",
+		"cat .../.../../../etc/passwd",
+	}
+
+	for _, cmd := range blockedCommands {
+		result := tool.Execute(ctx, map[string]any{"action": "run", "command": cmd})
+		if !result.IsError || !strings.Contains(result.ForLLM, "path traversal") {
+			t.Errorf("path traversal variant should be blocked: %q\n  got: %s", cmd, result.ForLLM)
+		}
+	}
+
+	// Legitimate commands with ... should not be blocked by path traversal check
+	allowedCommands := []string{
+		"echo ...",
+		"ls ...",
+	}
+
+	for _, cmd := range allowedCommands {
+		result := tool.Execute(ctx, map[string]any{"action": "run", "command": cmd})
+		// These should not be blocked by path traversal check specifically
+		if strings.Contains(result.ForLLM, "path traversal") {
+			t.Errorf("legitimate command with ... should not be blocked by traversal: %q", cmd)
+		}
+	}
+}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -1024,3 +1024,87 @@ func TestPathTraversalVariants(t *testing.T) {
 		}
 	}
 }
+
+// TestShellTool_RelativePathWithSlashAllowed verifies that local relative paths
+// under the workspace are not mistaken for absolute paths by the safety guard.
+func TestShellTool_RelativePathWithSlashAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptDir := filepath.Join(tmpDir, "skills", "calendar-query", "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("failed to create script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "query_calendar.py")
+	if err := os.WriteFile(scriptPath, []byte("calendar ok\n"), 0o644); err != nil {
+		t.Fatalf("failed to create script: %v", err)
+	}
+
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "cat skills/calendar-query/scripts/query_calendar.py",
+	})
+
+	if result.IsError {
+		t.Fatalf("relative workspace script path should be allowed, got: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, "calendar ok") {
+		t.Fatalf("expected script output, got: %s", result.ForLLM)
+	}
+}
+
+func TestShellTool_AttachedAbsolutePathsStillBlocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	commands := []string{
+		"cat --file=/etc/passwd",
+		"cc -I/etc main.c",
+		"echo -isystem/usr/include",
+	}
+
+	for _, cmd := range commands {
+		result := tool.Execute(context.Background(), map[string]any{"action": "run", "command": cmd})
+		if !result.IsError || !strings.Contains(result.ForLLM, "path outside working dir") {
+			t.Errorf("attached absolute path should be blocked: %q\n  got: %s", cmd, result.ForLLM)
+		}
+	}
+}
+
+func TestShellTool_OptionValueRelativeSymlinkEscapeBlocked(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "passwd"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatalf("failed to create outside file: %v", err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(workspace, "link")); err != nil {
+		t.Skipf("symlinks not supported in this environment: %v", err)
+	}
+
+	tool, err := NewExecTool(workspace, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "echo --config=link/passwd",
+	})
+
+	if !result.IsError || !strings.Contains(result.ForLLM, "path outside working dir") {
+		t.Fatalf("option value symlink escape should be blocked, got: %s", result.ForLLM)
+	}
+}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -1108,3 +1108,48 @@ func TestShellTool_OptionValueRelativeSymlinkEscapeBlocked(t *testing.T) {
 		t.Fatalf("option value symlink escape should be blocked, got: %s", result.ForLLM)
 	}
 }
+
+// TestShellTool_SchemelessURLDetection verifies that the scheme-less URL
+// detection logic in guardCommand correctly identifies web URL path components
+// (e.g., "//github.com" captured by the regex after "https:") and exempts them
+// from workspace sandbox checks. It also confirms that paths NOT preceded by a
+// recognized web scheme are still blocked.
+func TestShellTool_SchemelessURLDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	// Each of the 7 recognized web schemes should have its path component
+	// exempted from workspace boundary checks.
+	allowedCommands := []string{
+		"echo https://github.com",
+		"echo http://example.com",
+		"echo ftp://ftp.example.com",
+		"echo ftps://secure.example.com",
+		"echo sftp://sftp.example.com",
+		"echo ssh://git@github.com",
+		"echo git://github.com",
+	}
+
+	for _, cmd := range allowedCommands {
+		result := tool.Execute(context.Background(), map[string]any{"action": "run", "command": cmd})
+		if result.IsError && strings.Contains(result.ForLLM, "path outside working dir") {
+			t.Errorf("command with recognized web scheme should not be blocked: %s\n  error: %s", cmd, result.ForLLM)
+		}
+	}
+
+	// Multiple URLs with different schemes in a single command should all be exempt.
+	multiURLCommands := []string{
+		"echo https://github.com && curl http://example.com",
+		"wget ftp://a.com; curl https://b.com",
+	}
+
+	for _, cmd := range multiURLCommands {
+		result := tool.Execute(context.Background(), map[string]any{"action": "run", "command": cmd})
+		if result.IsError && strings.Contains(result.ForLLM, "path outside working dir") {
+			t.Errorf("command with multiple web URLs should not be blocked: %s\n  error: %s", cmd, result.ForLLM)
+		}
+	}
+}

--- a/pkg/tools/spawn.go
+++ b/pkg/tools/spawn.go
@@ -82,8 +82,14 @@ func (t *SpawnTool) execute(ctx context.Context, args map[string]any, cb AsyncCa
 		return ErrorResult("task is required and must be a non-empty string")
 	}
 
-	label, _ := args["label"].(string)
-	agentID, _ := args["agent_id"].(string)
+	label, ok := args["label"].(string)
+	if !ok {
+		label = ""
+	}
+	agentID, ok := args["agent_id"].(string)
+	if !ok {
+		agentID = ""
+	}
 
 	// Check allowlist if targeting a specific agent
 	if agentID != "" && t.allowlistCheck != nil {

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -369,7 +369,10 @@ func (t *SubagentTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		return ErrorResult("task is required").WithError(fmt.Errorf("task parameter is required"))
 	}
 
-	label, _ := args["label"].(string)
+	label, ok := args["label"].(string)
+	if !ok {
+		label = ""
+	}
 
 	// Build system prompt for subagent
 	systemPrompt := fmt.Sprintf(`You are a subagent. Complete the given task independently and provide a clear, concise result.

--- a/pkg/tools/toolloop.go
+++ b/pkg/tools/toolloop.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/logger"
@@ -146,6 +147,17 @@ func RunToolLoop(
 			wg.Add(1)
 			go func(idx int, tc providers.ToolCall) {
 				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						logger.ErrorCF("toolloop", "tool execution goroutine panic recovered",
+							map[string]any{
+								"tool":  tc.Name,
+								"panic": fmt.Sprintf("%v", r),
+								"stack": string(debug.Stack()),
+							})
+						results[idx].result = ErrorResult(fmt.Sprintf("internal panic in tool %s", tc.Name))
+					}
+				}()
 
 				argsJSON, err := json.Marshal(tc.Arguments)
 				if err != nil {

--- a/pkg/tools/toolloop.go
+++ b/pkg/tools/toolloop.go
@@ -108,7 +108,16 @@ func RunToolLoop(
 			Content: response.Content,
 		}
 		for _, tc := range normalizedToolCalls {
-			argumentsJSON, _ := json.Marshal(tc.Arguments)
+			argumentsJSON, err := json.Marshal(tc.Arguments)
+			if err != nil {
+				logger.ErrorCF("toolloop", "json.Marshal failed for tool arguments",
+					map[string]any{
+						"tool":       tc.Name,
+						"error":      err.Error(),
+						"iteration": iteration,
+					})
+				continue
+			}
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, providers.ToolCall{
 				ID:        tc.ID,
 				Type:      "function",
@@ -138,7 +147,17 @@ func RunToolLoop(
 			go func(idx int, tc providers.ToolCall) {
 				defer wg.Done()
 
-				argsJSON, _ := json.Marshal(tc.Arguments)
+				argsJSON, err := json.Marshal(tc.Arguments)
+				if err != nil {
+					logger.ErrorCF("toolloop", "json.Marshal failed for tool arguments",
+						map[string]any{
+							"tool":       tc.Name,
+							"error":      err.Error(),
+							"iteration": iteration,
+						})
+					results[idx].result = ErrorResult(fmt.Sprintf("json.Marshal error: %v", err))
+					return
+				}
 				argsPreview := utils.Truncate(string(argsJSON), 200)
 				logger.InfoCF("toolloop", fmt.Sprintf("Tool call: %s(%s)", tc.Name, argsPreview),
 					map[string]any{


### PR DESCRIPTION
## What this adds

Eight hand-ported upstream fixes to `pkg/tools`, three of them security-relevant. Part of the
picoclaw v0.2.7..v0.3.1 sync wave.

| Commit | Upstream | What |
|---|---|---|
| `22254e07` | `cb5d3312` | **Block PowerShell encoding bypass in the exec guard** |
| `61e345e5` | `17e47202` | **Allow workspace-relative exec paths** safely (`python ./script.py`) |
| `a0a4a183` | `b86ab718` | **Allow scheme-less URLs** in the workspace guard (`curl wttr.in/...`) |
| `31a25377` | `a6735517` | Tests for the scheme-less URL guard |
| `4fb72845` | `1719067a` | Handle `json.Marshal` error in toolloop tool-call arguments |
| `8c100e04` | `77017eb5` | `ok` checks on type assertions in `spawn.go` / `subagent.go` |
| `d38a8915` | `7af40d49` | Missing `action` arg for cron command jobs |
| `b3d14505` | `b292defd` | Panic recovery on core-path goroutines (**`pkg/tools` half only** — the `pkg/channels`/`pkg/events` half is in the upstream-correctness PR) |

## Safety-relevant properties

**We were genuinely exposed.** `defaultDenyPatterns` (`pkg/tools/shell.go:32`) was an entirely
POSIX-flavoured list — `rm -rf`, `sudo`, `| sh`, backticks — with **zero** encoding guards, while
`shell.go:270` invokes `powershell -NoProfile -NonInteractive -Command` and `Makefile:163,207` ship
`windows-amd64`. Vulnerable surface, guard infrastructure, and shipping Windows binaries all present.

Now blocked that previously was not: `[Text.Encoding]` / `[System.Text.Encoding]`,
`-EncodedCommand` short forms (`-e`, `-ec`, `-enc`), `.GetString([byte[]]` with whitespace variants,
`FromBase64String`, `[byte[]](...)` variable assignment, literal `\uXXXX` escapes, and `.../.../`
path-traversal variants. PowerShell `$env:VAR`, CMD `%VAR%`, and `~` are now expanded **before** the
workspace path check, closing `$env:USERPROFILE`-style escapes.

Deny patterns are split into all-platform defaults plus a Windows-only set, so the new rules add no
false positives on Linux/macOS.

Note this hardening matters more than usual for us: we have no OS-level process isolation for
agent-spawned subprocesses, so this regex layer is the only defence on that path.

## How it was tested

Verified independently in a clean worktree: `go generate ./...` + `go build ./...` clean,
**1600 tests pass** in `pkg/tools`, `golangci-lint v2.10.1` reports **0 issues**.

Real regression tests ship with the security fixes, not just the fixes:
`TestPowerShellEncodingBypass`, `TestPathTraversalVariants`, `TestShellTool_SchemelessURLDetection`,
`TestShellTool_RelativePathWithSlashAllowed`, `TestShellTool_OptionValueRelativeSymlinkEscapeBlocked`.

## Known limitations

- Windows-specific behaviour is validated by testing the `windowsDenyPatterns` regexes directly
  rather than by executing PowerShell, since CI runs on Linux/macOS. Upstream's runtime-gated Windows
  tests skip on non-Windows.
- Three upstream commits were assessed as **not applicable** rather than skipped for convenience:
  `734f53fb` targets functions (`runBackground`, `executeList`, `executePoll`, …) that return zero
  matches in our tree; `bb57e049`/`e70a9fca` fix a ticker-goroutine leak in a `SessionManager` that,
  in our fork, starts no goroutine at all (`pkg/session/manager.go:22`); `0bb0fc42` is already
  present — our `pkg/tools/cron.go:416` passes `sessionKey` where upstream's fix changed `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)