### PR TITLE
feat(voice): multi-backend voice transcription (Whisper, ElevenLabs, audio-model)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -794,7 +794,9 @@ type DevicesConfig struct {
 }
 
 type VoiceConfig struct {
-	EchoTranscription bool `json:"echo_transcription" env:"KHUNQUANT_VOICE_ECHO_TRANSCRIPTION"`
+	EchoTranscription  bool   `json:"echo_transcription" env:"KHUNQUANT_VOICE_ECHO_TRANSCRIPTION"`
+	ModelName          string `json:"model_name,omitempty" env:"KHUNQUANT_VOICE_MODEL_NAME"`
+	ElevenLabsAPIKey   string `json:"elevenlabs_api_key,omitzero" env:"KHUNQUANT_VOICE_ELEVENLABS_API_KEY"`
 }
 
 // DevMCPConfig controls the read-only developer MCP debug server.

--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -53,6 +53,16 @@ func ExtractProtocol(model string) (protocol, modelID string) {
 	return protocol, modelID
 }
 
+// ResolveAPIBase resolves the API base URL for a ModelConfig.
+// It returns the configured APIBase if set, otherwise the default for the protocol.
+func ResolveAPIBase(cfg *config.ModelConfig) string {
+	if base := strings.TrimSpace(cfg.APIBase); base != "" {
+		return base
+	}
+	protocol, _ := ExtractProtocol(cfg.Model)
+	return getDefaultAPIBase(protocol)
+}
+
 // CreateProviderFromConfig creates a provider based on the ModelConfig.
 // It uses the protocol prefix in the Model field to determine which provider to create.
 // Supported protocols: openai, litellm, anthropic, anthropic-messages, antigravity,

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,9 +16,22 @@ import (
 	"github.com/cryptoquantumwave/khunquant/pkg/media"
 )
 
+var audioExtensions = []string{".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".wma", ".amr", ".opus"}
+
+// AudioFormat returns the MIME audio subtype for a given audio file path.
+// For example, ".mp3" returns "mp3", ".wav" returns "wav", etc.
+func AudioFormat(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, supportedExt := range audioExtensions {
+		if ext == supportedExt {
+			return strings.TrimPrefix(ext, "."), nil
+		}
+	}
+	return "", fmt.Errorf("unsupported audio format for %q", path)
+}
+
 // IsAudioFile checks if a file is an audio file based on its filename extension and content type.
 func IsAudioFile(filename, contentType string) bool {
-	audioExtensions := []string{".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".wma"}
 	audioTypes := []string{"audio/", "application/ogg", "application/x-ogg"}
 
 	for _, ext := range audioExtensions {

--- a/pkg/utils/media_test.go
+++ b/pkg/utils/media_test.go
@@ -192,3 +192,77 @@ func TestDownloadFileSimple_Success(t *testing.T) {
 	}
 	defer os.Remove(path)
 }
+
+// --- AMR and OPUS audio format support (OneBot, Matrix) ---
+
+func TestIsAudioFile_AMRFormat(t *testing.T) {
+	// OneBot voice messages arrive as "voice.amr" with empty content type
+	if !utils.IsAudioFile("voice.amr", "") {
+		t.Error("IsAudioFile(\"voice.amr\", \"\"): expected true for OneBot voice")
+	}
+	// Also test with correct content type
+	if !utils.IsAudioFile("voice.amr", "audio/amr") {
+		t.Error("IsAudioFile(\"voice.amr\", \"audio/amr\"): expected true")
+	}
+}
+
+func TestIsAudioFile_OpusFormat(t *testing.T) {
+	// Matrix voice messages use .opus format
+	if !utils.IsAudioFile("audio.opus", "") {
+		t.Error("IsAudioFile(\"audio.opus\", \"\"): expected true for Matrix voice")
+	}
+	// Also test with correct content type
+	if !utils.IsAudioFile("audio.opus", "audio/opus") {
+		t.Error("IsAudioFile(\"audio.opus\", \"audio/opus\"): expected true")
+	}
+}
+
+// --- AudioFormat function ---
+
+func TestAudioFormat_SupportedFormats(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"clip.mp3", "mp3"},
+		{"audio.wav", "wav"},
+		{"voice.ogg", "ogg"},
+		{"speech.amr", "amr"},       // OneBot voice
+		{"stream.opus", "opus"},     // Matrix voice
+		{"track.m4a", "m4a"},
+		{"song.flac", "flac"},
+		{"recording.aac", "aac"},
+		{"music.wma", "wma"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := utils.AudioFormat(tt.path)
+			if err != nil {
+				t.Errorf("AudioFormat(%q) error: %v", tt.path, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AudioFormat(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAudioFormat_UnsupportedFormat(t *testing.T) {
+	_, err := utils.AudioFormat("file.txt")
+	if err == nil {
+		t.Error("AudioFormat(\"file.txt\"): expected error for unsupported format")
+	}
+}
+
+func TestAudioFormat_CaseInsensitive(t *testing.T) {
+	got, err := utils.AudioFormat("AUDIO.MP3")
+	if err != nil {
+		t.Errorf("AudioFormat(\"AUDIO.MP3\") error: %v", err)
+		return
+	}
+	if got != "mp3" {
+		t.Errorf("AudioFormat(\"AUDIO.MP3\") = %q, want %q", got, "mp3")
+	}
+}

--- a/pkg/voice/asr.go
+++ b/pkg/voice/asr.go
@@ -1,0 +1,109 @@
+package voice
+
+import (
+	"strings"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
+)
+
+const elevenLabsSupportedModelID = "scribe_v1"
+
+func ElevenLabsSupportedModelID() string {
+	return elevenLabsSupportedModelID
+}
+
+func supportsAudioTranscription(modelCfg *config.ModelConfig) bool {
+	protocol, _ := providers.ExtractProtocol(modelCfg.Model)
+
+	switch protocol {
+	case "openai", "azure",
+		"litellm", "openrouter", "groq", "zhipu", "gemini", "nvidia",
+		"ollama", "moonshot", "shengsuanyun", "deepseek", "cerebras",
+		"vivgrid", "volcengine", "vllm", "qwen-portal", "qwen-intl", "qwen-us",
+		"mistral", "avian", "minimax", "longcat", "modelscope", "novita",
+		"alibaba-coding", "zai":
+		// These protocols all go through the OpenAI-compatible or Azure provider path in
+		// providers.CreateProviderFromConfig, so they are the only ones that can supply
+		// the audio media payload shape expected by NewAudioModelTranscriber.
+
+		// TODO: Further restrict this by modelID, since not every model under these
+		// protocols supports audio transcription.
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsWhisperTranscription(modelCfg *config.ModelConfig) bool {
+	protocol, _ := providers.ExtractProtocol(modelCfg.Model)
+
+	switch protocol {
+	case "openai", "litellm", "openrouter", "groq", "zhipu", "gemini", "nvidia",
+		"ollama", "moonshot", "shengsuanyun", "deepseek", "cerebras",
+		"vivgrid", "volcengine", "vllm", "qwen-portal", "qwen-intl", "qwen-us",
+		"mistral", "avian", "minimax", "longcat", "modelscope", "novita",
+		"alibaba-coding", "zai", "mimo":
+		return true
+	default:
+		return false
+	}
+}
+
+func whisperModelID(modelCfg *config.ModelConfig) string {
+	if modelCfg == nil || modelCfg.APIKey.String() == "" {
+		return ""
+	}
+
+	if !supportsWhisperTranscription(modelCfg) {
+		return ""
+	}
+
+	_, modelID := providers.ExtractProtocol(modelCfg.Model)
+	if strings.Contains(strings.ToLower(modelID), "whisper") {
+		return modelID
+	}
+	return ""
+}
+
+func isElevenLabsTranscriptionModel(modelCfg *config.ModelConfig) bool {
+	if modelCfg == nil || modelCfg.APIKey.String() == "" {
+		return false
+	}
+
+	protocol, _ := providers.ExtractProtocol(modelCfg.Model)
+	return protocol == "elevenlabs"
+}
+
+func transcriberFromModelConfig(modelCfg *config.ModelConfig) Transcriber {
+	if modelCfg == nil {
+		return nil
+	}
+
+	if isElevenLabsTranscriptionModel(modelCfg) {
+		_, modelID := providers.ExtractProtocol(modelCfg.Model)
+		return NewElevenLabsTranscriber(modelCfg.APIKey.String(), modelCfg.APIBase, modelID)
+	}
+	if modelID := whisperModelID(modelCfg); modelID != "" {
+		return NewWhisperTranscriber(modelCfg)
+	}
+	if supportsAudioTranscription(modelCfg) {
+		return NewAudioModelTranscriber(modelCfg)
+	}
+	return nil
+}
+
+func fallbackTranscriberFromModelConfig(modelCfg *config.ModelConfig) Transcriber {
+	if modelCfg == nil {
+		return nil
+	}
+
+	if isElevenLabsTranscriptionModel(modelCfg) {
+		_, modelID := providers.ExtractProtocol(modelCfg.Model)
+		return NewElevenLabsTranscriber(modelCfg.APIKey.String(), modelCfg.APIBase, modelID)
+	}
+	if modelID := whisperModelID(modelCfg); modelID != "" {
+		return NewWhisperTranscriber(modelCfg)
+	}
+	return nil
+}

--- a/pkg/voice/asr_test.go
+++ b/pkg/voice/asr_test.go
@@ -1,0 +1,266 @@
+package voice
+
+import (
+	"testing"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+)
+
+func TestDetectTranscriberBackendSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		wantNil  bool
+		wantName string
+	}{
+		{
+			name:    "no config",
+			cfg:     &config.Config{},
+			wantNil: true,
+		},
+		{
+			name: "voice model name selects audio model transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "voice-gemini"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "voice-gemini",
+						Model:     "gemini/gemini-2.5-flash",
+						APIKey:    *config.NewSecureString("sk-gemini-model"),
+					},
+				},
+			},
+			wantName: "audio-model",
+		},
+		{
+			name: "voice model name alias selects elevenlabs transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "my-asr-model"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "my-asr-model",
+						Model:     "elevenlabs/scribe_v1",
+						APIKey:    *config.NewSecureString("sk_elevenlabs_test"),
+					},
+				},
+			},
+			wantName: "elevenlabs",
+		},
+		{
+			name: "voice model name alias selects whisper transcriber for groq",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "my-asr-model"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "my-asr-model",
+						Model:     "groq/whisper-large-v3",
+						APIKey:    *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "whisper",
+		},
+		{
+			name: "openai whisper alias selects whisper transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "my-asr-model"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "my-asr-model",
+						Model:     "openai/whisper-1",
+						APIKey:    *config.NewSecureString("sk-openai-model"),
+					},
+				},
+			},
+			wantName: "whisper",
+		},
+		{
+			name: "whisper via model list fallback",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{ModelName: "openai", Model: "openai/gpt-4o", APIKey: *config.NewSecureString("sk-openai")},
+					{
+						ModelName: "groq",
+						Model:     "groq/whisper-large-v3-turbo",
+						APIKey:    *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "whisper",
+		},
+		{
+			name: "voice model name alias selects non-gemini audio model transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "my-asr-model"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "my-asr-model",
+						Model:     "openai/gpt-4o-audio-preview",
+						APIKey:    *config.NewSecureString("sk-openai"),
+					},
+				},
+			},
+			wantName: "audio-model",
+		},
+		{
+			name: "voice model name selects azure audio model transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "voice-azure-audio"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "voice-azure-audio",
+						Model:     "azure/my-audio-deployment",
+						APIKey:    *config.NewSecureString("sk-azure"),
+						APIBase:   "https://example.openai.azure.com",
+					},
+				},
+			},
+			wantName: "audio-model",
+		},
+		{
+			name: "voice model name with non openai compatible protocol does not select audio model transcriber",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "voice-anthropic"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "voice-anthropic",
+						Model:     "anthropic/claude-sonnet-4.6",
+						APIKey:    *config.NewSecureString("sk-anthropic"),
+					},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "groq model list entry without key is skipped",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{Model: "groq/whisper-large-v3"},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "model list entry without key is skipped",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "groq",
+						Model:     "groq/whisper-large-v3",
+						APIKey:    *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "whisper",
+		},
+		{
+			name: "missing voice model name config returns nil",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{ModelName: "missing"},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "other",
+						Model:     "gemini/gemini-2.5-flash",
+						APIKey:    *config.NewSecureString("sk-other-model"),
+					},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "elevenlabs voice config key",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{Model: "elevenlabs/scribe_v1", APIKey: *config.NewSecureString("sk_elevenlabs_test")},
+				},
+			},
+			wantName: "elevenlabs",
+		},
+		{
+			name: "elevenlabs takes priority over groq model list",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{Model: "elevenlabs/scribe_v1", APIKey: *config.NewSecureString("sk_elevenlabs_test")},
+					{
+						ModelName: "groq",
+						Model:     "groq/llama-3.3-70b",
+						APIKey:    *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "elevenlabs",
+		},
+		{
+			name: "voice model name takes priority over elevenlabs",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{
+					ModelName: "voice-gemini",
+				},
+				ModelList: []config.ModelConfig{
+					{Model: "elevenlabs/scribe_v1", APIKey: *config.NewSecureString("sk_elevenlabs_test")},
+					{
+						ModelName: "voice-gemini",
+						Model:     "gemini/gemini-2.5-flash",
+						APIKey:    *config.NewSecureString("sk-gemini-model"),
+					},
+				},
+			},
+			wantName: "audio-model",
+		},
+		{
+			name: "direct elevenlabs api key takes priority over model list",
+			cfg: &config.Config{
+				Voice: config.VoiceConfig{
+					ElevenLabsAPIKey: "sk_elevenlabs_direct",
+				},
+				ModelList: []config.ModelConfig{
+					{
+						ModelName: "groq",
+						Model:     "groq/whisper-large-v3",
+						APIKey:    *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "elevenlabs",
+		},
+		{
+			name: "groq provider key fallback",
+			cfg: &config.Config{
+				Providers: config.ProvidersConfig{
+					Groq: config.ProviderConfig{APIKey: "sk-groq-direct"},
+				},
+			},
+			wantName: "groq",
+		},
+		{
+			name: "groq llama via model list without whisper in name uses groq backend",
+			cfg: &config.Config{
+				ModelList: []config.ModelConfig{
+					{
+						Model: "groq/llama-3.3-70b",
+						APIKey: *config.NewSecureString("sk-groq-model"),
+					},
+				},
+			},
+			wantName: "groq",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := DetectTranscriber(tc.cfg)
+			if tc.wantNil {
+				if tr != nil {
+					t.Errorf("DetectTranscriber() = %v, want nil", tr)
+				}
+				return
+			}
+			if tr == nil {
+				t.Fatal("DetectTranscriber() = nil, want non-nil")
+			}
+			if got := tr.Name(); got != tc.wantName {
+				t.Errorf("Name() = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}

--- a/pkg/voice/audio_model.go
+++ b/pkg/voice/audio_model.go
@@ -1,0 +1,96 @@
+package voice
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers/protocoltypes"
+	"github.com/cryptoquantumwave/khunquant/pkg/utils"
+)
+
+type AudioModelTranscriber struct {
+	provider providers.LLMProvider
+	modelID  string
+	prompt   string
+}
+
+const (
+	defaultTranscriptionPrompt = "Transcribe this audio."
+)
+
+func NewAudioModelTranscriber(modelCfg *config.ModelConfig) *AudioModelTranscriber {
+	if modelCfg == nil {
+		return nil
+	}
+
+	logger.DebugCF("voice", "Creating audio model transcriber", map[string]any{
+		"has_api_key": modelCfg.APIKey.String() != "",
+		"api_base":    modelCfg.APIBase,
+		"model":       modelCfg.Model,
+	})
+
+	provider, modelID, err := providers.CreateProviderFromConfig(modelCfg)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to create audio model provider", map[string]any{"error": err})
+		return nil
+	}
+
+	return &AudioModelTranscriber{
+		provider: provider,
+		modelID:  modelID,
+		prompt:   defaultTranscriptionPrompt,
+	}
+}
+
+func (t *AudioModelTranscriber) Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error) {
+	logger.InfoCF("voice", "Starting audio model transcription", map[string]any{
+		"audio_file": audioFilePath,
+		"model":      t.modelID,
+	})
+
+	audioBytes, err := os.ReadFile(audioFilePath)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to read audio file", map[string]any{"path": audioFilePath, "error": err})
+		return nil, fmt.Errorf("failed to read audio file: %w", err)
+	}
+
+	format, err := utils.AudioFormat(audioFilePath)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to detect audio format", map[string]any{"path": audioFilePath, "error": err})
+		return nil, err
+	}
+
+	resp, err := t.provider.Chat(ctx, []protocoltypes.Message{
+		{
+			Role:    "user",
+			Content: t.prompt,
+			Media: []string{
+				fmt.Sprintf("data:audio/%s;base64,%s", format, base64.StdEncoding.EncodeToString(audioBytes)),
+			},
+		},
+	}, nil, t.modelID, map[string]any{
+		"temperature": 0,
+	})
+	if err != nil {
+		logger.ErrorCF("voice", "Audio model transcription request failed", map[string]any{"error": err})
+		return nil, fmt.Errorf("transcription request failed: %w", err)
+	}
+
+	text := strings.TrimSpace(resp.Content)
+	logger.InfoCF("voice", "Audio model transcription completed successfully", map[string]any{
+		"text_length":           len(text),
+		"transcription_preview": utils.Truncate(text, 50),
+	})
+
+	return &TranscriptionResponse{Text: text}, nil
+}
+
+func (t *AudioModelTranscriber) Name() string {
+	return "audio-model"
+}

--- a/pkg/voice/audio_model_test.go
+++ b/pkg/voice/audio_model_test.go
@@ -1,0 +1,203 @@
+package voice
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers/protocoltypes"
+)
+
+var _ Transcriber = (*AudioModelTranscriber)(nil)
+
+type fakeLLMProvider struct {
+	chatFunc func(
+		ctx context.Context,
+		messages []protocoltypes.Message,
+		tools []protocoltypes.ToolDefinition,
+		model string,
+		options map[string]any,
+	) (*protocoltypes.LLMResponse, error)
+}
+
+func (p *fakeLLMProvider) Chat(
+	ctx context.Context,
+	messages []protocoltypes.Message,
+	tools []protocoltypes.ToolDefinition,
+	model string,
+	options map[string]any,
+) (*protocoltypes.LLMResponse, error) {
+	if p.chatFunc == nil {
+		return nil, nil
+	}
+	return p.chatFunc(ctx, messages, tools, model, options)
+}
+
+func (p *fakeLLMProvider) GetDefaultModel() string {
+	return ""
+}
+
+func TestAudioModelTranscriberName(t *testing.T) {
+	tr := &AudioModelTranscriber{}
+	if got := tr.Name(); got != "audio-model" {
+		t.Errorf("Name() = %q, want %q", got, "audio-model")
+	}
+}
+
+func TestNewAudioModelTranscriberInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.ModelConfig
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+		},
+		{
+			name: "missing api key",
+			cfg: &config.ModelConfig{
+				Model: "gemini/gemini-2.5-flash",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tr := NewAudioModelTranscriber(tt.cfg); tr != nil {
+				t.Fatalf("NewAudioModelTranscriber() = %#v, want nil", tr)
+			}
+		})
+	}
+}
+
+func TestAudioModelTranscriberTranscribe(t *testing.T) {
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "clip.ogg")
+	audioData := []byte("fake-audio-data")
+	if err := os.WriteFile(audioPath, audioData, 0o644); err != nil {
+		t.Fatalf("failed to write fake audio file: %v", err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		tr := &AudioModelTranscriber{
+			provider: &fakeLLMProvider{
+				chatFunc: func(
+					ctx context.Context,
+					messages []protocoltypes.Message,
+					tools []protocoltypes.ToolDefinition,
+					model string,
+					options map[string]any,
+				) (*protocoltypes.LLMResponse, error) {
+					if ctx == nil {
+						t.Fatal("context should not be nil")
+					}
+					if tools != nil {
+						t.Fatalf("tools = %#v, want nil", tools)
+					}
+					if model != "gemini-2.5-flash" {
+						t.Fatalf("model = %q, want %q", model, "gemini-2.5-flash")
+					}
+					if len(messages) != 1 {
+						t.Fatalf("len(messages) = %d, want 1", len(messages))
+					}
+					msg := messages[0]
+					if msg.Role != "user" {
+						t.Fatalf("role = %q, want %q", msg.Role, "user")
+					}
+					if msg.Content != defaultTranscriptionPrompt {
+						t.Fatalf("prompt = %q, want %q", msg.Content, defaultTranscriptionPrompt)
+					}
+					if len(msg.Media) != 1 {
+						t.Fatalf("len(media) = %d, want 1", len(msg.Media))
+					}
+					wantMedia := "data:audio/ogg;base64," + base64.StdEncoding.EncodeToString(audioData)
+					if msg.Media[0] != wantMedia {
+						t.Fatalf("media = %q, want %q", msg.Media[0], wantMedia)
+					}
+					if len(options) != 1 {
+						t.Fatalf("options = %#v, want only temperature", options)
+					}
+					if got := options["temperature"]; got != 0 {
+						t.Fatalf("temperature = %#v, want 0", got)
+					}
+
+					return &protocoltypes.LLMResponse{Content: "  hello from gemini \n"}, nil
+				},
+			},
+			modelID: "gemini-2.5-flash",
+			prompt:  defaultTranscriptionPrompt,
+		}
+
+		resp, err := tr.Transcribe(context.Background(), audioPath)
+		if err != nil {
+			t.Fatalf("Transcribe() error: %v", err)
+		}
+		if resp.Text != "hello from gemini" {
+			t.Fatalf("Text = %q, want %q", resp.Text, "hello from gemini")
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		tr := &AudioModelTranscriber{
+			provider: &fakeLLMProvider{
+				chatFunc: func(
+					ctx context.Context,
+					messages []protocoltypes.Message,
+					tools []protocoltypes.ToolDefinition,
+					model string,
+					options map[string]any,
+				) (*protocoltypes.LLMResponse, error) {
+					return nil, errors.New("upstream failure")
+				},
+			},
+			modelID: "gemini-2.5-flash",
+			prompt:  defaultTranscriptionPrompt,
+		}
+
+		_, err := tr.Transcribe(context.Background(), audioPath)
+		if err == nil {
+			t.Fatal("expected error for provider failure, got nil")
+		}
+		if got := err.Error(); got != "transcription request failed: upstream failure" {
+			t.Fatalf("error = %q, want %q", got, "transcription request failed: upstream failure")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		tr := &AudioModelTranscriber{
+			provider: &fakeLLMProvider{},
+			modelID:  "gemini-2.5-flash",
+			prompt:   defaultTranscriptionPrompt,
+		}
+
+		_, err := tr.Transcribe(context.Background(), filepath.Join(tmpDir, "nonexistent.ogg"))
+		if err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("unsupported audio format", func(t *testing.T) {
+		badPath := filepath.Join(tmpDir, "clip.txt")
+		if err := os.WriteFile(badPath, []byte("not-audio"), 0o644); err != nil {
+			t.Fatalf("failed to write fake file: %v", err)
+		}
+
+		tr := &AudioModelTranscriber{
+			provider: &fakeLLMProvider{},
+			modelID:  "gemini-2.5-flash",
+			prompt:   defaultTranscriptionPrompt,
+		}
+
+		_, err := tr.Transcribe(context.Background(), badPath)
+		if err == nil {
+			t.Fatal("expected error for unsupported audio format, got nil")
+		}
+		if got := err.Error(); got != `unsupported audio format for "`+badPath+`"` {
+			t.Fatalf("error = %q, want unsupported format error", got)
+		}
+	})
+}

--- a/pkg/voice/elevenlabs.go
+++ b/pkg/voice/elevenlabs.go
@@ -1,0 +1,150 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
+	"github.com/cryptoquantumwave/khunquant/pkg/utils"
+)
+
+// ElevenLabsTranscriber uses the ElevenLabs Scribe API for speech-to-text.
+type ElevenLabsTranscriber struct {
+	apiKey     string
+	apiBase    string
+	modelID    string
+	httpClient *http.Client
+}
+
+func NewElevenLabsTranscriber(apiKey, apiBase, modelID string) *ElevenLabsTranscriber {
+	logger.DebugCF("voice", "Creating ElevenLabs transcriber", map[string]any{"has_api_key": apiKey != ""})
+
+	if apiBase == "" {
+		apiBase = "https://api.elevenlabs.io"
+	}
+	if modelID == "" || modelID != ElevenLabsSupportedModelID() {
+		modelID = ElevenLabsSupportedModelID()
+	}
+
+	return &ElevenLabsTranscriber{
+		apiKey:  apiKey,
+		apiBase: apiBase,
+		modelID: modelID,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}
+}
+
+func (t *ElevenLabsTranscriber) Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error) {
+	logger.InfoCF("voice", "Starting ElevenLabs transcription", map[string]any{"audio_file": audioFilePath})
+
+	audioFile, err := os.Open(audioFilePath)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to open audio file", map[string]any{"path": audioFilePath, "error": err})
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer audioFile.Close()
+
+	fileInfo, err := audioFile.Stat()
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to get file info", map[string]any{"path": audioFilePath, "error": err})
+		return nil, fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	logger.DebugCF("voice", "Audio file details", map[string]any{
+		"size_bytes": fileInfo.Size(),
+		"file_name":  filepath.Base(audioFilePath),
+	})
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	part, err := writer.CreateFormFile("file", filepath.Base(audioFilePath))
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to create form file", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	if _, err = io.Copy(part, audioFile); err != nil {
+		logger.ErrorCF("voice", "Failed to copy file content", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to copy file content: %w", err)
+	}
+
+	if err = writer.WriteField("model_id", t.modelID); err != nil {
+		return nil, fmt.Errorf("failed to write model_id field: %w", err)
+	}
+
+	if err = writer.Close(); err != nil {
+		logger.ErrorCF("voice", "Failed to close multipart writer", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	url := t.apiBase + "/v1/speech-to-text"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &requestBody)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to create request", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Xi-Api-Key", t.apiKey)
+
+	logger.DebugCF("voice", "Sending transcription request to ElevenLabs API", map[string]any{
+		"url":                url,
+		"request_size_bytes": requestBody.Len(),
+		"file_size_bytes":    fileInfo.Size(),
+	})
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to send request", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to read response", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.ErrorCF("voice", "ElevenLabs API error", map[string]any{
+			"status_code": resp.StatusCode,
+			"response":    string(body),
+		})
+		return nil, fmt.Errorf("ElevenLabs API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	logger.DebugCF("voice", "Received response from ElevenLabs API", map[string]any{
+		"status_code":         resp.StatusCode,
+		"response_size_bytes": len(body),
+	})
+
+	var result TranscriptionResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		logger.ErrorCF("voice", "Failed to unmarshal response", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	logger.InfoCF("voice", "ElevenLabs transcription completed successfully", map[string]any{
+		"text_length":           len(result.Text),
+		"language":              result.Language,
+		"transcription_preview": utils.Truncate(result.Text, 50),
+	})
+
+	return &result, nil
+}
+
+func (t *ElevenLabsTranscriber) Name() string {
+	return "elevenlabs"
+}

--- a/pkg/voice/elevenlabs_test.go
+++ b/pkg/voice/elevenlabs_test.go
@@ -1,0 +1,160 @@
+package voice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Ensure ElevenLabsTranscriber satisfies the Transcriber interface at compile time.
+var _ Transcriber = (*ElevenLabsTranscriber)(nil)
+
+func TestElevenLabsTranscriberName(t *testing.T) {
+	tr := NewElevenLabsTranscriber("sk_test", "", "scribe_v1")
+	if got := tr.Name(); got != "elevenlabs" {
+		t.Errorf("Name() = %q, want %q", got, "elevenlabs")
+	}
+}
+
+func TestElevenLabsTranscribe(t *testing.T) {
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "clip.ogg")
+	if err := os.WriteFile(audioPath, []byte("fake-audio-data"), 0o644); err != nil {
+		t.Fatalf("failed to write fake audio file: %v", err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/speech-to-text" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			if r.Header.Get("Xi-Api-Key") != "sk_test" {
+				t.Errorf("unexpected xi-api-key header: %s", r.Header.Get("Xi-Api-Key"))
+			}
+			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("ParseMediaType() error = %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("content-type = %q, want multipart/form-data", mediaType)
+			}
+			reader := multipart.NewReader(r.Body, params["boundary"])
+			var gotModelID string
+			for {
+				part, err := reader.NextPart()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("NextPart() error = %v", err)
+				}
+				if part.FormName() != "model_id" {
+					continue
+				}
+				body, err := io.ReadAll(part)
+				if err != nil {
+					t.Fatalf("ReadAll(part) error = %v", err)
+				}
+				gotModelID = strings.TrimSpace(string(body))
+			}
+			if gotModelID != "scribe_v1" {
+				t.Fatalf("model_id = %q, want %q", gotModelID, "scribe_v1")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TranscriptionResponse{
+				Text:     "hello from elevenlabs",
+				Language: "en",
+			})
+		}))
+		defer srv.Close()
+
+		tr := NewElevenLabsTranscriber("sk_test", "", "scribe_v1")
+		tr.apiBase = srv.URL
+
+		resp, err := tr.Transcribe(context.Background(), audioPath)
+		if err != nil {
+			t.Fatalf("Transcribe() error: %v", err)
+		}
+		if resp.Text != "hello from elevenlabs" {
+			t.Errorf("Text = %q, want %q", resp.Text, "hello from elevenlabs")
+		}
+		if resp.Language != "en" {
+			t.Errorf("Language = %q, want %q", resp.Language, "en")
+		}
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"error":"invalid_api_key"}`, http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		tr := NewElevenLabsTranscriber("sk_bad", "", "scribe_v1")
+		tr.apiBase = srv.URL
+
+		_, err := tr.Transcribe(context.Background(), audioPath)
+		if err == nil {
+			t.Fatal("expected error for non-200 response, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		tr := NewElevenLabsTranscriber("sk_test", "", "scribe_v1")
+		_, err := tr.Transcribe(context.Background(), filepath.Join(tmpDir, "nonexistent.ogg"))
+		if err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("unsupported model falls back to scribe_v1", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("ParseMediaType() error = %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("content-type = %q, want multipart/form-data", mediaType)
+			}
+			reader := multipart.NewReader(r.Body, params["boundary"])
+			var gotModelID string
+			for {
+				part, err := reader.NextPart()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("NextPart() error = %v", err)
+				}
+				if part.FormName() != "model_id" {
+					continue
+				}
+				body, err := io.ReadAll(part)
+				if err != nil {
+					t.Fatalf("ReadAll(part) error = %v", err)
+				}
+				gotModelID = strings.TrimSpace(string(body))
+			}
+			if gotModelID != "scribe_v1" {
+				t.Fatalf("model_id = %q, want runtime fallback to %q", gotModelID, "scribe_v1")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TranscriptionResponse{Text: "ok"})
+		}))
+		defer srv.Close()
+
+		tr := NewElevenLabsTranscriber("sk_test", "", "unsupported-model")
+		tr.apiBase = srv.URL
+
+		if _, err := tr.Transcribe(context.Background(), audioPath); err != nil {
+			t.Fatalf("Transcribe() error: %v", err)
+		}
+	})
+}

--- a/pkg/voice/transcriber.go
+++ b/pkg/voice/transcriber.go
@@ -166,15 +166,53 @@ func (t *GroqTranscriber) Name() string {
 // DetectTranscriber inspects cfg and returns the appropriate Transcriber, or
 // nil if no supported transcription provider is configured.
 func DetectTranscriber(cfg *config.Config) Transcriber {
-	// Direct Groq provider config takes priority.
+	if cfg == nil {
+		return nil
+	}
+
+	// 1. Check if an explicit voice model is configured
+	if modelName := strings.TrimSpace(cfg.Voice.ModelName); modelName != "" {
+		modelCfg, err := cfg.GetModelConfig(modelName)
+		if err == nil && modelCfg != nil {
+			if tr := transcriberFromModelConfig(modelCfg); tr != nil {
+				return tr
+			}
+		}
+	}
+
+	// 2. Check if ElevenLabs API key is directly configured
+	if key := strings.TrimSpace(cfg.Voice.ElevenLabsAPIKey); key != "" {
+		return NewElevenLabsTranscriber(key, "", "")
+	}
+
+	// 3. Scan ModelList for compatible backends (fallback scanning)
+	for _, mc := range cfg.ModelList {
+		if tr := fallbackTranscriberFromModelConfig(&mc); tr != nil {
+			return tr
+		}
+	}
+
+	// 4. Legacy Groq fallback - maintains backward compatibility
 	if key := cfg.Providers.Groq.APIKey; key != "" {
 		return NewGroqTranscriber(key)
 	}
-	// Fall back to any model-list entry that uses the groq/ protocol.
+
+	// 5. Fall back to any model-list entry that uses the groq/ protocol
 	for _, mc := range cfg.ModelList {
 		if strings.HasPrefix(mc.Model, "groq/") && mc.APIKey.String() != "" {
-			return NewGroqTranscriber(mc.APIKey.String())
+			// For backward compatibility, check if the model contains "whisper".
+			// If it does, use WhisperTranscriber; otherwise use GroqTranscriber.
+			if strings.Contains(strings.ToLower(mc.Model), "whisper") {
+				tr := NewWhisperTranscriber(&mc)
+				if tr != nil {
+					return tr
+				}
+			} else {
+				// Non-whisper groq models (e.g., groq/llama-3.3-70b) use Groq transcriber
+				return NewGroqTranscriber(mc.APIKey.String())
+			}
 		}
 	}
+
 	return nil
 }

--- a/pkg/voice/transcriber_test.go
+++ b/pkg/voice/transcriber_test.go
@@ -158,3 +158,74 @@ func TestTranscribe(t *testing.T) {
 		}
 	})
 }
+
+// TestGroqBackwardCompat verifies that existing Groq-only configurations
+// continue to work without any config changes, proving backward compatibility.
+func TestGroqBackwardCompat(t *testing.T) {
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "clip.ogg")
+	if err := os.WriteFile(audioPath, []byte("fake-audio-data"), 0o644); err != nil {
+		t.Fatalf("failed to write fake audio file: %v", err)
+	}
+
+	// Simulate an existing user config with only Groq provider API key.
+	// This should continue to work exactly as before.
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Groq: config.ProviderConfig{APIKey: "sk-groq-test"},
+		},
+	}
+
+	// DetectTranscriber should return a Groq transcriber
+	tr := DetectTranscriber(cfg)
+	if tr == nil {
+		t.Fatal("DetectTranscriber() = nil, want Groq transcriber")
+	}
+	if got := tr.Name(); got != "groq" {
+		t.Errorf("Name() = %q, want %q", got, "groq")
+	}
+
+	// Verify the Groq transcriber makes the correct API request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify endpoint
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		// Verify authorization header format
+		if r.Header.Get("Authorization") != "Bearer sk-groq-test" {
+			t.Errorf("unexpected Authorization header: %s", r.Header.Get("Authorization"))
+		}
+		// Verify multipart form submission with model field
+		if err := r.ParseMultipartForm(1024 * 1024); err != nil {
+			t.Errorf("ParseMultipartForm() error: %v", err)
+		}
+		// In the Groq transcriber, the model field is "whisper-large-v3"
+		// (This is the existing hardcoded model in the Groq implementation)
+		if model := r.FormValue("model"); model != "whisper-large-v3" {
+			t.Errorf("model field = %q, want %q", model, "whisper-large-v3")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TranscriptionResponse{
+			Text:     "backward compat verified",
+			Language: "en",
+		})
+	}))
+	defer srv.Close()
+
+	// Override the Groq transcriber's API base to use our test server
+	groqTr, ok := tr.(*GroqTranscriber)
+	if !ok {
+		t.Fatalf("expected *GroqTranscriber, got %T", tr)
+	}
+	groqTr.apiBase = srv.URL
+
+	// Perform transcription and verify it works
+	resp, err := groqTr.Transcribe(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Transcribe() error: %v", err)
+	}
+	if resp.Text != "backward compat verified" {
+		t.Errorf("Text = %q, want %q", resp.Text, "backward compat verified")
+	}
+}

--- a/pkg/voice/whisper.go
+++ b/pkg/voice/whisper.go
@@ -1,0 +1,241 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
+	"github.com/cryptoquantumwave/khunquant/pkg/utils"
+)
+
+type WhisperTranscriber struct {
+	apiKey       string
+	apiBase      string
+	modelID      string
+	providerName string
+	httpClient   *http.Client
+}
+
+func NewWhisperTranscriber(modelCfg *config.ModelConfig) *WhisperTranscriber {
+	if modelCfg == nil {
+		return nil
+	}
+
+	protocol, modelID := providers.ExtractProtocol(modelCfg.Model)
+	if modelID == "" {
+		modelID = strings.TrimSpace(modelCfg.Model)
+	}
+
+	tr := newWhisperTranscriber(
+		modelCfg.APIKey.String(),
+		providers.ResolveAPIBase(modelCfg),
+		modelID,
+		protocol,
+	)
+	if tr == nil {
+		return nil
+	}
+
+	logger.DebugCF("voice", "Creating whisper transcriber", map[string]any{
+		"api_base": tr.apiBase,
+		"has_key":  tr.apiKey != "",
+		"model":    tr.modelID,
+		"provider": tr.providerName,
+	})
+	return tr
+}
+
+func newWhisperTranscriber(apiKey, apiBase, modelID, providerName string) *WhisperTranscriber {
+	if modelID == "" {
+		return nil
+	}
+	if providerName == "" {
+		providerName = "whisper"
+	}
+	return &WhisperTranscriber{
+		apiKey:       apiKey,
+		apiBase:      strings.TrimRight(apiBase, "/"),
+		modelID:      modelID,
+		providerName: providerName,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+func (t *WhisperTranscriber) transcriptionURL() string {
+	base := strings.TrimRight(t.apiBase, "/")
+	if strings.HasSuffix(base, "/audio/transcriptions") {
+		return base
+	}
+	return base + "/audio/transcriptions"
+}
+
+func (t *WhisperTranscriber) TranscribeData(
+	ctx context.Context,
+	data []byte,
+	filename string,
+) (*TranscriptionResponse, error) {
+	logger.InfoCF("voice", "Starting whisper transcription from memory", map[string]any{
+		"bytes":    len(data),
+		"filename": filename,
+		"model":    t.modelID,
+		"provider": t.providerName,
+	})
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to create whisper form file", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	if _, copyErr := io.Copy(part, bytes.NewReader(data)); copyErr != nil {
+		logger.ErrorCF("voice", "Failed to copy whisper file content", map[string]any{"error": copyErr})
+		return nil, fmt.Errorf("failed to copy file content: %w", copyErr)
+	}
+
+	if err = writer.WriteField("model", t.modelID); err != nil {
+		logger.ErrorCF("voice", "Failed to write whisper model field", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to write model field: %w", err)
+	}
+
+	if err = writer.WriteField("response_format", "json"); err != nil {
+		logger.ErrorCF("voice", "Failed to write whisper response_format field", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to write response_format field: %w", err)
+	}
+
+	if err = writer.Close(); err != nil {
+		logger.ErrorCF("voice", "Failed to close whisper multipart writer", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	return t.doRequest(ctx, &requestBody, writer.FormDataContentType(), int64(len(data)))
+}
+
+func (t *WhisperTranscriber) Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error) {
+	logger.InfoCF("voice", "Starting whisper transcription", map[string]any{
+		"audio_file": audioFilePath,
+		"model":      t.modelID,
+		"provider":   t.providerName,
+	})
+
+	audioFile, err := os.Open(audioFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file %s: %w", audioFilePath, err)
+	}
+	defer audioFile.Close()
+
+	fileInfo, err := audioFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat audio file %s: %w", audioFilePath, err)
+	}
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	part, err := writer.CreateFormFile("file", filepath.Base(audioFilePath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	if _, copyErr := io.Copy(part, audioFile); copyErr != nil {
+		return nil, fmt.Errorf("failed to copy audio data: %w", copyErr)
+	}
+
+	if err = writer.WriteField("model", t.modelID); err != nil {
+		return nil, fmt.Errorf("failed to write model field: %w", err)
+	}
+
+	if err = writer.WriteField("response_format", "json"); err != nil {
+		return nil, fmt.Errorf("failed to write response_format field: %w", err)
+	}
+
+	if err = writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	return t.doRequest(ctx, &requestBody, writer.FormDataContentType(), fileInfo.Size())
+}
+
+func (t *WhisperTranscriber) doRequest(
+	ctx context.Context,
+	requestBody *bytes.Buffer,
+	contentType string,
+	fileSize int64,
+) (*TranscriptionResponse, error) {
+	url := t.transcriptionURL()
+	req, err := http.NewRequestWithContext(ctx, "POST", url, requestBody)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to create whisper request", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	if t.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+t.apiKey)
+	}
+
+	logger.DebugCF("voice", "Sending whisper transcription request", map[string]any{
+		"file_size_bytes":    fileSize,
+		"model":              t.modelID,
+		"provider":           t.providerName,
+		"request_size_bytes": requestBody.Len(),
+		"url":                url,
+	})
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to send whisper request", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.ErrorCF("voice", "Failed to read whisper response", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.ErrorCF("voice", "Whisper API error", map[string]any{
+			"provider":    t.providerName,
+			"response":    string(body),
+			"status_code": resp.StatusCode,
+		})
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result TranscriptionResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		logger.ErrorCF("voice", "Failed to unmarshal whisper response", map[string]any{"error": err})
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	logger.InfoCF("voice", "Whisper transcription completed successfully", map[string]any{
+		"duration_seconds":      result.Duration,
+		"language":              result.Language,
+		"provider":              t.providerName,
+		"text_length":           len(result.Text),
+		"transcription_preview": utils.Truncate(result.Text, 50),
+	})
+
+	return &result, nil
+}
+
+func (t *WhisperTranscriber) Name() string {
+	return "whisper"
+}

--- a/pkg/voice/whisper_test.go
+++ b/pkg/voice/whisper_test.go
@@ -1,0 +1,102 @@
+package voice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+)
+
+func TestWhisperTranscriberTranscribeDataUsesConfiguredModel(t *testing.T) {
+	var gotModel string
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-openai-test" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer sk-openai-test")
+		}
+
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("MultipartReader() error: %v", err)
+		}
+
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("NextPart() error: %v", err)
+			}
+
+			data, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+
+			if part.FormName() == "model" {
+				gotModel = string(data)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(TranscriptionResponse{Text: "hello from whisper"}); err != nil {
+			t.Fatalf("Encode() error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tr := NewWhisperTranscriber(&config.ModelConfig{
+		Model:   "openai/whisper-1",
+		APIBase: server.URL,
+		APIKey:  *config.NewSecureString("sk-openai-test"),
+	})
+	tr.httpClient = server.Client()
+
+	resp, err := tr.TranscribeData(context.Background(), []byte("audio"), "clip.ogg")
+	if err != nil {
+		t.Fatalf("TranscribeData() error: %v", err)
+	}
+	if resp.Text != "hello from whisper" {
+		t.Errorf("Text = %q, want %q", resp.Text, "hello from whisper")
+	}
+	if gotModel != "whisper-1" {
+		t.Errorf("model field = %q, want %q", gotModel, "whisper-1")
+	}
+	if gotPath != "/audio/transcriptions" {
+		t.Errorf("path = %q, want %q", gotPath, "/audio/transcriptions")
+	}
+}
+
+func TestWhisperTranscriberUsesEndpointAPIBaseWithoutDoubleAppend(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(TranscriptionResponse{Text: "ok"}); err != nil {
+			t.Fatalf("Encode() error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tr := NewWhisperTranscriber(&config.ModelConfig{
+		Model:   "groq/whisper-large-v3",
+		APIBase: server.URL + "/audio/transcriptions",
+		APIKey:  *config.NewSecureString("sk-groq-test"),
+	})
+	tr.httpClient = server.Client()
+
+	if _, err := tr.TranscribeData(context.Background(), []byte("audio"), "clip.ogg"); err != nil {
+		t.Fatalf("TranscribeData() error: %v", err)
+	}
+	if gotPath != "/audio/transcriptions" {
+		t.Errorf("path = %q, want %q", gotPath, "/audio/transcriptions")
+	}
+}


### PR DESCRIPTION
## What this adds

Replaces our Groq-only voice transcription with a multi-backend ASR implementation ported from
upstream picoclaw's `pkg/audio/asr`, absorbed into our existing `pkg/voice`.

| Commit | What |
|---|---|
| `1b730e83` | Whisper, ElevenLabs, and audio-model transcribers + backend selector |
| `4ae2bbd7` | Recognize `.amr` and `.opus` voice messages as audio |
| `99fa6a64` | ASR backend tests and backward-compatibility coverage |

**Before:** `pkg/voice/transcriber.go`, 180 lines, Groq only (`whisper-large-v3`).
`DetectTranscriber(cfg)` returned a Groq transcriber or `nil`.

**After:** three backends —
- **Whisper** across ~25 OpenAI-compatible protocols (openai, groq, openrouter, zhipu, gemini,
  nvidia, ollama, deepseek, mistral, …) — roughly 20 endpoints we already hold credentials for
- **ElevenLabs** Scribe (`scribe_v1`)
- **Audio-model**: native transcription via multimodal LLMs

`DetectTranscriber` becomes a cascade: explicit voice model → direct ElevenLabs key → scan
`ModelList` for a transcription-capable protocol → **Groq fallback**.

## Safety-relevant properties

- **`go.mod` and `go.sum` are byte-for-byte untouched.** Verified.
- **Zero `pion` / `webrtc` / `rtp` references anywhere on the branch.** This is deliberate: upstream's
  `pkg/audio/asr/agent.go` (realtime RTP/VAD orchestrator) is the only file importing `pkg/bus` and
  the pion stack, and it is **excluded**. That avoids a `pkg/bus` snapshot gap *and* keeps WebRTC out
  of a project targeting <10MB RAM.
- **Backward compatible.** Upstream's `asr.Transcriber` interface and `TranscriptionResponse` struct
  are byte-identical to ours (our `pkg/voice` was derived from an earlier revision of the same code),
  so `pkg/agent/loop.go:680` `SetTranscriber(voice.Transcriber)` is unchanged — no call-site edits.
  An existing Groq-only config behaves identically with no config change.
- No new dependencies; no secrets; tests make no live API calls.

## Also fixes a fork-local bug

`utils.IsAudioFile` (`pkg/utils/media.go`) matched `.mp3 .wav .ogg .m4a .flac .aac .wma` but **omitted
`.amr`**. OneBot saves voice messages as `voice.amr` (`pkg/channels/onebot/onebot.go:807-812`) and
`pkg/agent/loop.go:702` gates transcription on `IsAudioFile` — so OneBot voice only transcribed when
the remote server happened to send an `audio/*` content type. Upstream has not fixed this either.

## How it was tested

876 lines of tests across 6 files. Verified independently:

- `TestGroqBackwardCompat` — Groq-only config, asserted against an `httptest` server on **request
  shape** (endpoint, multipart form, model field), not on a name string.
- `asr_test.go` — table test over the full `DetectTranscriber` cascade including `wantNil` cases.
- `IsAudioFile("voice.amr", "")` asserted with an **empty content type** — the exact OneBot condition
  that was broken.
- Per-backend tests for auth header shape (ElevenLabs uses `Xi-Api-Key`, not Bearer), endpoint path
  construction, and base64 data-URI payloads.

`go test ./pkg/voice/... ./pkg/utils/...` → ok. `golangci-lint v2.10.1` → 0 issues. Verified again
merged with the other three wave-1 branches: 6154 tests pass, lint 0, govulncheck exit 0.

## Known limitations

- **TTS is deliberately out of scope.** Upstream's `pkg/audio/tts/` is cleanly separable and can be
  adopted later if voice *replies* are wanted.
- `pkg/audio/ogg.go` and `sentence.go` were **not** ported — they were verified TTS-side
  (`SplitSentences` → `discord/discord.go:895`, `DecodeOggOpus` → `discord/voice.go:131`), not ASR.
- Ported as a v0.3.1 snapshot rather than cherry-picks: the ASR subtree predates the analysed range,
  and every audio file the three in-range commits touch is absent from our fork.
- `groq/whisper-*` entries now report `Name() == "whisper"` rather than `"groq"`. `Name()` is consumed
  in exactly two places (`cmd/khunquant/internal/gateway/helpers.go:275` and `:624`), both log lines —
  cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)