### PR TITLE
feat(agent,config): restrict which MCP servers an agent may load

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -90,7 +90,11 @@ func NewAgentInstance(
 
 	model := resolveAgentModel(agentCfg, defaults)
 	fallbacks := resolveAgentFallbacks(agentCfg, defaults)
-	agentMCPServerAllowlist := resolveAgentMCPServerAllowlist(nil)
+	var mcpServers []string
+	if agentCfg != nil && agentCfg.MCPServers != nil {
+		mcpServers = agentCfg.MCPServers
+	}
+	agentMCPServerAllowlist := resolveAgentMCPServerAllowlist(mcpServers)
 
 	restrict := defaults.RestrictToWorkspace
 	readRestrict := restrict && !defaults.AllowReadOutsideWorkspace

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -49,6 +49,7 @@ type AgentInstance struct {
 	Tools                     *tools.ToolRegistry
 	Subagents                 *config.SubagentsConfig
 	SkillsFilter              []string
+	MCPServerAllowlist        map[string]struct{}
 	Candidates                []providers.FallbackCandidate
 
 	// snapshotStore is the shared snapshot database, closed when the agent shuts down.
@@ -89,6 +90,7 @@ func NewAgentInstance(
 
 	model := resolveAgentModel(agentCfg, defaults)
 	fallbacks := resolveAgentFallbacks(agentCfg, defaults)
+	agentMCPServerAllowlist := resolveAgentMCPServerAllowlist(nil)
 
 	restrict := defaults.RestrictToWorkspace
 	readRestrict := restrict && !defaults.AllowReadOutsideWorkspace
@@ -451,6 +453,7 @@ func NewAgentInstance(
 		Tools:                     toolsRegistry,
 		Subagents:                 subagents,
 		SkillsFilter:              skillsFilter,
+		MCPServerAllowlist:        agentMCPServerAllowlist,
 		Candidates:                candidates,
 		Router:                    router,
 		LightCandidates:           lightCandidates,
@@ -524,6 +527,16 @@ func resolveAgentFallbacks(agentCfg *config.AgentConfig, defaults *config.AgentD
 		return agentCfg.Model.Fallbacks
 	}
 	return defaults.ModelFallbacks
+}
+
+// AllowsMCPServer checks if an MCP server is allowed by the agent's allowlist.
+// If the allowlist is nil (no explicit configuration), all servers are allowed.
+func (a *AgentInstance) AllowsMCPServer(serverName string) bool {
+	if a == nil || a.MCPServerAllowlist == nil {
+		return true
+	}
+	_, ok := a.MCPServerAllowlist[strings.ToLower(strings.TrimSpace(serverName))]
+	return ok
 }
 
 func compilePatterns(patterns []string) []*regexp.Regexp {

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -497,3 +497,105 @@ func TestAgentInstance_AllowsMCPServer(t *testing.T) {
 		}
 	})
 }
+
+func TestAgentInstance_MCPServersFromConfig_Restricts(t *testing.T) {
+	workspace := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:   workspace,
+				ModelName:   "test-model",
+				MaxTokens:   1000,
+				Temperature: ptr(0.5),
+			},
+		},
+	}
+
+	agentCfg := &config.AgentConfig{
+		ID:         "restricted",
+		Workspace:  workspace,
+		MCPServers: []string{"github", "filesystem"},
+	}
+
+	agent := NewAgentInstance(agentCfg, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if !agent.AllowsMCPServer("github") {
+		t.Fatal("expected github to be allowed from config")
+	}
+	if !agent.AllowsMCPServer("filesystem") {
+		t.Fatal("expected filesystem to be allowed from config")
+	}
+	if agent.AllowsMCPServer("slack") {
+		t.Fatal("expected slack to be blocked by config allowlist")
+	}
+}
+
+func TestAgentInstance_MCPServersFromConfig_MixedCase(t *testing.T) {
+	workspace := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:   workspace,
+				ModelName:   "test-model",
+				MaxTokens:   1000,
+				Temperature: ptr(0.5),
+			},
+		},
+	}
+
+	agentCfg := &config.AgentConfig{
+		ID:         "mixedcase",
+		Workspace:  workspace,
+		MCPServers: []string{"GitHub", "FileSystem"},
+	}
+
+	agent := NewAgentInstance(agentCfg, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if !agent.AllowsMCPServer("github") {
+		t.Fatal("expected lowercase github to match uppercase config")
+	}
+	if !agent.AllowsMCPServer("GITHUB") {
+		t.Fatal("expected uppercase GITHUB to match mixed-case config")
+	}
+	if !agent.AllowsMCPServer("filesystem") {
+		t.Fatal("expected lowercase filesystem to match mixed-case config")
+	}
+}
+
+func TestAgentInstance_NoMCPServersConfig_AllowsAll(t *testing.T) {
+	workspace := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:   workspace,
+				ModelName:   "test-model",
+				MaxTokens:   1000,
+				Temperature: ptr(0.5),
+			},
+		},
+	}
+
+	agentCfg := &config.AgentConfig{
+		ID:        "noconfig",
+		Workspace: workspace,
+	}
+
+	agent := NewAgentInstance(agentCfg, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if !agent.AllowsMCPServer("github") {
+		t.Fatal("expected github to be allowed when no allowlist configured")
+	}
+	if !agent.AllowsMCPServer("slack") {
+		t.Fatal("expected slack to be allowed when no allowlist configured")
+	}
+	if !agent.AllowsMCPServer("filesystem") {
+		t.Fatal("expected filesystem to be allowed when no allowlist configured")
+	}
+}
+
+func ptr(f float64) *float64 {
+	return &f
+}

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -474,3 +474,26 @@ func TestNewAgentInstance_InvalidExecConfigDoesNotExit(t *testing.T) {
 		t.Fatal("read_file tool should still be registered")
 	}
 }
+
+func TestAgentInstance_AllowsMCPServer(t *testing.T) {
+	t.Run("nil allowlist allows all", func(t *testing.T) {
+		agent := &AgentInstance{}
+		if !agent.AllowsMCPServer("github") {
+			t.Fatal("expected nil MCP allowlist to allow all servers")
+		}
+	})
+
+	t.Run("explicit allowlist filters servers", func(t *testing.T) {
+		agent := &AgentInstance{
+			MCPServerAllowlist: map[string]struct{}{
+				"github": {},
+			},
+		}
+		if !agent.AllowsMCPServer("GitHub") {
+			t.Fatal("expected MCP server matching to be case-insensitive")
+		}
+		if agent.AllowsMCPServer("filesystem") {
+			t.Fatal("expected filesystem to be blocked by MCP allowlist")
+		}
+	})
+}

--- a/pkg/agent/loop_mcp.go
+++ b/pkg/agent/loop_mcp.go
@@ -9,8 +9,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
 	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 	"github.com/cryptoquantumwave/khunquant/pkg/mcp"
 	"github.com/cryptoquantumwave/khunquant/pkg/tools"
@@ -68,8 +70,18 @@ func (al *AgentLoop) ensureMCPInitialized(ctx context.Context) error {
 		return nil
 	}
 
+	mcpCfg := filterMCPConfigServers(al.cfg.Tools.MCP, al.registry.allowedMCPServers())
+	if len(mcpCfg.Servers) == 0 {
+		logger.InfoCF(
+			"agent",
+			"No MCP servers selected after applying per-agent mcpServers allowlists",
+			nil,
+		)
+		return nil
+	}
+
 	findValidServer := false
-	for _, serverCfg := range al.cfg.Tools.MCP.Servers {
+	for _, serverCfg := range mcpCfg.Servers {
 		if serverCfg.Enabled {
 			findValidServer = true
 		}
@@ -88,8 +100,7 @@ func (al *AgentLoop) ensureMCPInitialized(ctx context.Context) error {
 			workspacePath = defaultAgent.Workspace
 		}
 
-		if err := mcpManager.LoadFromMCPConfig(ctx, al.cfg.Tools.MCP, workspacePath); err != nil {
-			al.mcp.setInitErr(fmt.Errorf("failed to load MCP servers: %w", err))
+		if err := mcpManager.LoadFromMCPConfig(ctx, mcpCfg, workspacePath); err != nil {
 			logger.WarnCF("agent", "Failed to load MCP servers, MCP tools will not be available",
 				map[string]any{
 					"error": err.Error(),
@@ -116,6 +127,15 @@ func (al *AgentLoop) ensureMCPInitialized(ctx context.Context) error {
 				for _, agentID := range agentIDs {
 					agent, ok := al.registry.GetAgent(agentID)
 					if !ok {
+						continue
+					}
+					if !agent.AllowsMCPServer(serverName) {
+						logger.DebugCF("agent", "Skipped MCP tool registration by agent mcpServers allowlist",
+							map[string]any{
+								"agent_id": agentID,
+								"server":   serverName,
+								"tool":     tool.Name,
+							})
 						continue
 					}
 
@@ -198,4 +218,24 @@ func (al *AgentLoop) ensureMCPInitialized(ctx context.Context) error {
 	})
 
 	return al.mcp.getInitErr()
+}
+
+func filterMCPConfigServers(
+	mcpCfg config.MCPConfig,
+	allowed map[string]struct{},
+) config.MCPConfig {
+	if allowed == nil {
+		return mcpCfg
+	}
+
+	filtered := mcpCfg
+	filtered.Servers = make(map[string]config.MCPServerConfig)
+	for serverName, serverCfg := range mcpCfg.Servers {
+		normalizedName := strings.ToLower(strings.TrimSpace(serverName))
+		if _, ok := allowed[normalizedName]; ok {
+			filtered.Servers[serverName] = serverCfg
+		}
+	}
+
+	return filtered
 }

--- a/pkg/agent/loop_mcp_test.go
+++ b/pkg/agent/loop_mcp_test.go
@@ -88,3 +88,59 @@ func TestEnsureMCPInitialized_AllServersDisabled(t *testing.T) {
 		t.Errorf("ensureMCPInitialized with all disabled servers should succeed: %v", err)
 	}
 }
+
+func TestAgentRegistry_AllowedMCPServers(t *testing.T) {
+	t.Run("returns nil when any agent allows all servers", func(t *testing.T) {
+		registry := &AgentRegistry{
+			agents: map[string]*AgentInstance{
+				"main":     {ID: "main", MCPServerAllowlist: nil},
+				"research": {ID: "research", MCPServerAllowlist: map[string]struct{}{"github": {}}},
+			},
+		}
+
+		if allowed := registry.allowedMCPServers(); allowed != nil {
+			t.Fatalf("expected nil union when one agent allows all, got %v", allowed)
+		}
+	})
+
+	t.Run("returns union of explicit allowlists", func(t *testing.T) {
+		registry := &AgentRegistry{
+			agents: map[string]*AgentInstance{
+				"main":     {ID: "main", MCPServerAllowlist: map[string]struct{}{"github": {}}},
+				"research": {ID: "research", MCPServerAllowlist: map[string]struct{}{"filesystem": {}}},
+			},
+		}
+
+		allowed := registry.allowedMCPServers()
+		if len(allowed) != 2 {
+			t.Fatalf("len(allowed) = %d, want 2", len(allowed))
+		}
+		if _, ok := allowed["github"]; !ok {
+			t.Fatal("expected github in allowed MCP server union")
+		}
+		if _, ok := allowed["filesystem"]; !ok {
+			t.Fatal("expected filesystem in allowed MCP server union")
+		}
+	})
+}
+
+func TestFilterMCPConfigServers(t *testing.T) {
+	mcpCfg := config.MCPConfig{
+		ToolConfig: config.ToolConfig{Enabled: true},
+		Servers: map[string]config.MCPServerConfig{
+			"github":     {Enabled: true},
+			"filesystem": {Enabled: true},
+		},
+	}
+
+	filtered := filterMCPConfigServers(mcpCfg, map[string]struct{}{"github": {}})
+	if len(filtered.Servers) != 1 {
+		t.Fatalf("len(filtered.Servers) = %d, want 1", len(filtered.Servers))
+	}
+	if _, ok := filtered.Servers["github"]; !ok {
+		t.Fatal("expected github server to remain after filtering")
+	}
+	if _, ok := filtered.Servers["filesystem"]; ok {
+		t.Fatal("expected filesystem server to be removed by filtering")
+	}
+}

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -80,6 +80,33 @@ func (r *AgentRegistry) ListAgentIDs() []string {
 	return ids
 }
 
+// allowedMCPServers returns the union of all MCP servers allowed by any agent.
+// If any agent has a nil allowlist (allowing all servers), nil is returned.
+// Otherwise, the union of all explicit allowlists is returned.
+func (r *AgentRegistry) allowedMCPServers() map[string]struct{} {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.agents) == 0 {
+		return nil
+	}
+
+	union := make(map[string]struct{})
+	for _, agent := range r.agents {
+		if agent == nil {
+			continue
+		}
+		if agent.MCPServerAllowlist == nil {
+			return nil
+		}
+		for serverName := range agent.MCPServerAllowlist {
+			union[serverName] = struct{}{}
+		}
+	}
+
+	return union
+}
+
 // CanSpawnSubagent checks if parentAgentID is allowed to spawn targetAgentID.
 func (r *AgentRegistry) CanSpawnSubagent(parentAgentID, targetAgentID string) bool {
 	parent, ok := r.GetAgent(parentAgentID)

--- a/pkg/agent/tool_allowlist.go
+++ b/pkg/agent/tool_allowlist.go
@@ -1,0 +1,28 @@
+package agent
+
+import (
+	"strings"
+)
+
+// resolveAgentMCPServerAllowlist returns a case-insensitive set of allowed MCP server names.
+// If no allowlist is configured, it returns nil (allowing all servers).
+// Server names are normalized to lowercase for matching.
+func resolveAgentMCPServerAllowlist(mcpServers []string) map[string]struct{} {
+	if len(mcpServers) == 0 {
+		return nil
+	}
+
+	allowlist := make(map[string]struct{}, len(mcpServers))
+	for _, raw := range mcpServers {
+		trimmed := strings.ToLower(strings.TrimSpace(raw))
+		if trimmed == "" {
+			continue
+		}
+		allowlist[trimmed] = struct{}{}
+	}
+
+	if len(allowlist) == 0 {
+		return nil
+	}
+	return allowlist
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -437,13 +437,14 @@ func (m AgentModelConfig) MarshalJSON() ([]byte, error) {
 }
 
 type AgentConfig struct {
-	ID        string            `json:"id"`
-	Default   bool              `json:"default,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Workspace string            `json:"workspace,omitempty"`
-	Model     *AgentModelConfig `json:"model,omitempty"`
-	Skills    []string          `json:"skills,omitempty"`
-	Subagents *SubagentsConfig  `json:"subagents,omitempty"`
+	ID         string            `json:"id"`
+	Default    bool              `json:"default,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Workspace  string            `json:"workspace,omitempty"`
+	Model      *AgentModelConfig `json:"model,omitempty"`
+	Skills     []string          `json:"skills,omitempty"`
+	MCPServers []string          `json:"mcp_servers,omitempty"`
+	Subagents  *SubagentsConfig  `json:"subagents,omitempty"`
 }
 
 type SubagentsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -815,3 +815,51 @@ func TestFlexibleStringSlice_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+
+func TestAgentConfig_MCPServersRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		config AgentConfig
+	}{
+		{
+			name: "with mcp_servers",
+			config: AgentConfig{
+				ID:         "test",
+				MCPServers: []string{"github", "filesystem"},
+			},
+		},
+		{
+			name: "with nil mcp_servers",
+			config: AgentConfig{
+				ID:         "test",
+				MCPServers: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.config)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			var roundTrip AgentConfig
+			if err := json.Unmarshal(data, &roundTrip); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			if tt.config.MCPServers == nil && roundTrip.MCPServers != nil {
+				t.Fatal("MCPServers not preserved after round-trip")
+			}
+			if len(tt.config.MCPServers) == len(roundTrip.MCPServers) {
+				for i, expected := range tt.config.MCPServers {
+					if roundTrip.MCPServers[i] != expected {
+						t.Fatalf("MCPServers[%d] = %q, want %q", i, roundTrip.MCPServers[i], expected)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this adds

A per-agent **MCP server allowlist**, hand-ported from upstream picoclaw `847218ef` + `f5f1dc98` and
adapted to this fork's configuration idiom. Wave 2 of the v0.2.7..v0.3.1 sync.

Configure it per agent:
```json
{ "id": "restricted", "mcp_servers": ["github", "filesystem"] }
```
That agent can then load `github` and `filesystem` and **nothing else**.

| Commit | What |
|---|---|
| `a864eaad` | Allowlist plumbing — `AgentInstance.MCPServerAllowlist`, `AllowsMCPServer()`, `tool_allowlist.go` (upstream `847218ef`) |
| `a180a071` | Filter MCP config to allowed servers before loading (upstream `f5f1dc98`) |
| `87abd751` | Add `MCPServers []string` to `AgentConfig` — the configuration source |
| `8aa4ffeb` | Wire config through to the allowlist, plus end-to-end tests |

## Safety-relevant properties

**Backward compatible by construction.** An agent with no `mcp_servers` key gets a `nil` allowlist,
and `AllowsMCPServer()` returns `true` for everything — today's behaviour exactly. Only an
explicitly populated list restricts anything. There is a dedicated test for this
(`TestAgentInstance_NoMCPServersConfig_AllowsAll`).

**Deliberate divergence from upstream, in our favour.** `filterMCPConfigServers` normalizes the
lookup with `strings.ToLower(strings.TrimSpace(...))`, so a mixed-case config key like `"GitHub"`
still matches an allowlisted `"github"`. Upstream's version silently drops it. Pinned by
`TestAgentInstance_MCPServersFromConfig_MixedCase`.

**Not ported:** upstream drives this from AGENT.md frontmatter, a subsystem this fork does not have.
Rather than import it, the allowlist reads from `AgentConfig`, alongside the existing `Skills` and
`Subagents.AllowAgents` per-agent allowlists.

## How it was tested

Reviewed and verified independently of the authoring agent, including a **mutation test** — because
a passing test does not prove a control works:

```
# force the control to permit everything
AllowsMCPServer() { return true }
→ TestAgentInstance_MCPServersFromConfig_Restricts FAILS
  "expected slack to be blocked by config allowlist"
# restored
→ PASS
```

So the test genuinely detects the defect it guards against, rather than passing for an unrelated reason.

Also green: `go generate ./...`, `go build ./...`, full `go test ./...` (0 failures),
`golangci-lint v2.10.1` (0 issues) — and verified again with the other three wave-2 branches merged
together.

## Known limitations

- The allowlist gates which servers an agent *loads*. It is not a sandbox: an allowed server retains
  whatever capability it already had.
- An earlier revision of this branch was rejected in review because the control was **inert** —
  the config source had not been wired, so it permitted every server while appearing to restrict.
  That is fixed here; the mutation test above exists specifically to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)