### PR TITLE
fix(tools): scope remote cron command access

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1024,8 +1024,9 @@ type WebToolsConfig struct {
 }
 
 type CronToolsConfig struct {
-	ToolConfig         `    envPrefix:"KHUNQUANT_TOOLS_CRON_"`
-	ExecTimeoutMinutes int `                                 env:"KHUNQUANT_TOOLS_CRON_EXEC_TIMEOUT_MINUTES" json:"exec_timeout_minutes"` // 0 means no timeout
+	ToolConfig            `    envPrefix:"KHUNQUANT_TOOLS_CRON_"`
+	ExecTimeoutMinutes    int      `                                 env:"KHUNQUANT_TOOLS_CRON_EXEC_TIMEOUT_MINUTES"     json:"exec_timeout_minutes"` // 0 means no timeout
+	CommandAllowedRemotes []string `                                 env:"KHUNQUANT_TOOLS_CRON_COMMAND_ALLOWED_REMOTES" json:"command_allowed_remotes"`
 }
 
 type ExecConfig struct {

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -129,13 +130,17 @@ func (t *CronTool) Execute(ctx context.Context, args map[string]any) *ToolResult
 	case "add":
 		return t.addJob(ctx, args)
 	case "list":
-		return t.listJobs()
+		return t.listJobs(ctx)
+	case "get":
+		return t.getJob(ctx, args)
+	case "update":
+		return t.updateJob(ctx, args)
 	case "remove":
-		return t.removeJob(args)
+		return t.removeJob(ctx, args)
 	case "enable":
-		return t.enableJob(args, true)
+		return t.enableJob(ctx, args, true)
 	case "disable":
-		return t.enableJob(args, false)
+		return t.enableJob(ctx, args, false)
 	default:
 		return ErrorResult(fmt.Sprintf("unknown action: %s", action))
 	}
@@ -252,16 +257,24 @@ func (t *CronTool) addJob(ctx context.Context, args map[string]any) *ToolResult 
 	return SilentResult(fmt.Sprintf("Cron job added: %s (id: %s)", job.Name, job.ID))
 }
 
-func (t *CronTool) listJobs() *ToolResult {
+func (t *CronTool) listJobs(ctx context.Context) *ToolResult {
 	jobs := t.cronService.ListJobs(false)
 
-	if len(jobs) == 0 {
+	// Filter jobs by access control
+	var accessible []*cron.CronJob
+	for i := range jobs {
+		if t.canAccessJob(ctx, &jobs[i]) {
+			accessible = append(accessible, &jobs[i])
+		}
+	}
+
+	if len(accessible) == 0 {
 		return SilentResult("No scheduled jobs")
 	}
 
 	var result strings.Builder
 	result.WriteString("Scheduled jobs:\n")
-	for _, j := range jobs {
+	for _, j := range accessible {
 		var scheduleInfo string
 		if j.Schedule.Kind == "every" && j.Schedule.EveryMS != nil {
 			scheduleInfo = fmt.Sprintf("every %ds", *j.Schedule.EveryMS/1000)
@@ -278,10 +291,18 @@ func (t *CronTool) listJobs() *ToolResult {
 	return SilentResult(result.String())
 }
 
-func (t *CronTool) removeJob(args map[string]any) *ToolResult {
+func (t *CronTool) removeJob(ctx context.Context, args map[string]any) *ToolResult {
 	jobID, ok := args["job_id"].(string)
 	if !ok || jobID == "" {
 		return ErrorResult("job_id is required for remove")
+	}
+
+	job := t.cronService.GetJob(jobID)
+	if job == nil {
+		return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
+	}
+	if !t.canAccessJob(ctx, job) {
+		return ErrorResult(fmt.Sprintf("Job %s is not accessible from this channel", jobID))
 	}
 
 	if t.cronService.RemoveJob(jobID) {
@@ -290,14 +311,22 @@ func (t *CronTool) removeJob(args map[string]any) *ToolResult {
 	return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
 }
 
-func (t *CronTool) enableJob(args map[string]any, enable bool) *ToolResult {
+func (t *CronTool) enableJob(ctx context.Context, args map[string]any, enable bool) *ToolResult {
 	jobID, ok := args["job_id"].(string)
 	if !ok || jobID == "" {
 		return ErrorResult("job_id is required for enable/disable")
 	}
 
-	job := t.cronService.EnableJob(jobID, enable)
+	job := t.cronService.GetJob(jobID)
 	if job == nil {
+		return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
+	}
+	if !t.canAccessJob(ctx, job) {
+		return ErrorResult(fmt.Sprintf("Job %s is not accessible from this channel", jobID))
+	}
+
+	updatedJob := t.cronService.EnableJob(jobID, enable)
+	if updatedJob == nil {
 		return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
 	}
 
@@ -305,7 +334,7 @@ func (t *CronTool) enableJob(args map[string]any, enable bool) *ToolResult {
 	if !enable {
 		status = "disabled"
 	}
-	return SilentResult(fmt.Sprintf("Cron job '%s' %s", job.Name, status))
+	return SilentResult(fmt.Sprintf("Cron job '%s' %s", updatedJob.Name, status))
 }
 
 // ExecuteJob executes a cron job through the agent
@@ -417,4 +446,222 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		t.executor.PublishResponseIfNeeded(ctx, channel, chatID, sessionKey, response)
 	}
 	return "ok"
+}
+
+func (t *CronTool) getJob(ctx context.Context, args map[string]any) *ToolResult {
+	jobID, errResult := requiredCronJobID(args, "get")
+	if errResult != nil {
+		return errResult
+	}
+
+	job := t.cronService.GetJob(jobID)
+	if job == nil {
+		return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
+	}
+
+	if !t.canAccessJob(ctx, job) {
+		return ErrorResult(fmt.Sprintf("Job %s is not accessible from this channel", jobID))
+	}
+
+	return SilentResult(formatCronJobJSON(job))
+}
+
+func (t *CronTool) updateJob(ctx context.Context, args map[string]any) *ToolResult {
+	jobID, errResult := requiredCronJobID(args, "update")
+	if errResult != nil {
+		return errResult
+	}
+
+	job := t.cronService.GetJob(jobID)
+	if job == nil {
+		return ErrorResult(fmt.Sprintf("Job %s not found", jobID))
+	}
+
+	if !t.canAccessJob(ctx, job) {
+		return ErrorResult(fmt.Sprintf("Job %s is not accessible from this channel", jobID))
+	}
+
+	patches := 0
+
+	if name, present, errResult := optionalNonEmptyString(args, "name"); errResult != nil {
+		return errResult
+	} else if present {
+		job.Name = name
+		patches++
+	}
+
+	if message, present, errResult := optionalNonEmptyString(args, "message"); errResult != nil {
+		return errResult
+	} else if present {
+		job.Payload.Message = message
+		patches++
+	}
+
+	if schedule, present, errResult := schedulePatch(args); errResult != nil {
+		return errResult
+	} else if present {
+		job.Schedule = schedule
+		patches++
+	}
+
+	if patches == 0 {
+		return ErrorResult("at least one of name, message, or schedule parameters is required")
+	}
+
+	if err := t.cronService.UpdateJob(job); err != nil {
+		return ErrorResult(fmt.Sprintf("update failed: %v", err))
+	}
+
+	return SilentResult(fmt.Sprintf("Cron job '%s' updated", job.Name))
+}
+
+func (t *CronTool) canAccessJob(ctx context.Context, job *cron.CronJob) bool {
+	channel := ToolChannel(ctx)
+	chatID := ToolChatID(ctx)
+
+	// If no channel/chatID context, allow access (internal call)
+	if channel == "" && chatID == "" {
+		return true
+	}
+
+	// If channel/chatID are set, apply strict access control
+	if channel == "" || chatID == "" {
+		return false
+	}
+	if job.Payload.Channel != channel || job.Payload.To != chatID {
+		return false
+	}
+	if job.Payload.Command != "" {
+		return isCommandAllowedRemote(channel, chatID, t.cfg.Tools.Cron.CommandAllowedRemotes)
+	}
+	return true
+}
+
+// Helper functions for cron tool
+
+func requiredCronJobID(args map[string]any, action string) (string, *ToolResult) {
+	jobID, ok := args["job_id"].(string)
+	if !ok || jobID == "" {
+		return "", ErrorResult(fmt.Sprintf("job_id is required for %s", action))
+	}
+	return jobID, nil
+}
+
+func optionalString(args map[string]any, key string) (string, bool, *ToolResult) {
+	value, present := args[key]
+	if !present {
+		return "", false, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false, ErrorResult(fmt.Sprintf("%s must be a string", key))
+	}
+	return text, true, nil
+}
+
+func optionalNonEmptyString(args map[string]any, key string) (string, bool, *ToolResult) {
+	_, present := args[key]
+	if !present {
+		return "", false, nil
+	}
+	text, _, errResult := optionalString(args, key)
+	if errResult != nil {
+		return "", false, errResult
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", false, ErrorResult(fmt.Sprintf("%s cannot be empty", key))
+	}
+	return text, true, nil
+}
+
+func schedulePatch(args map[string]any) (cron.CronSchedule, bool, *ToolResult) {
+	var schedule cron.CronSchedule
+	patches := 0
+
+	if atSeconds, present, errResult := optionalUint64(args, "at_seconds"); errResult != nil {
+		return schedule, false, errResult
+	} else if present {
+		atMS := int64(atSeconds * 1000)
+		schedule = cron.CronSchedule{Kind: "at", AtMS: &atMS}
+		patches++
+	}
+
+	if everySeconds, present, errResult := optionalUint64(args, "every_seconds"); errResult != nil {
+		return schedule, false, errResult
+	} else if present {
+		everyMS := int64(everySeconds * 1000)
+		schedule = cron.CronSchedule{Kind: "every", EveryMS: &everyMS}
+		patches++
+	}
+
+	if cronExpr, present, errResult := optionalNonEmptyString(args, "cron_expr"); errResult != nil {
+		return schedule, false, errResult
+	} else if present {
+		schedule = cron.CronSchedule{Kind: "cron", Expr: cronExpr}
+		patches++
+	}
+
+	if patches > 1 {
+		return schedule, false, ErrorResult("only one of at_seconds, every_seconds, or cron_expr may be patched")
+	}
+
+	return schedule, patches == 1, nil
+}
+
+func optionalUint64(args map[string]any, key string) (uint64, bool, *ToolResult) {
+	value, present := args[key]
+	if !present {
+		return 0, false, nil
+	}
+
+	switch v := value.(type) {
+	case float64:
+		if v < 0 {
+			return 0, false, ErrorResult(fmt.Sprintf("%s must be non-negative", key))
+		}
+		return uint64(v), true, nil
+	case int:
+		if v < 0 {
+			return 0, false, ErrorResult(fmt.Sprintf("%s must be non-negative", key))
+		}
+		return uint64(v), true, nil
+	case int64:
+		if v < 0 {
+			return 0, false, ErrorResult(fmt.Sprintf("%s must be non-negative", key))
+		}
+		return uint64(v), true, nil
+	default:
+		return 0, false, ErrorResult(fmt.Sprintf("%s must be a number", key))
+	}
+}
+
+func formatCronJobJSON(job *cron.CronJob) string {
+	data, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Sprintf("%+v", *job)
+	}
+	return string(data)
+}
+
+func isCommandAllowedRemote(channel, chatID string, allowed []string) bool {
+	if channel == "" {
+		return false
+	}
+
+	target := channel
+	if chatID != "" {
+		target = channel + ":" + chatID
+	}
+
+	for _, entry := range allowed {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == "*" || entry == channel || entry == target {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -517,14 +517,12 @@ func (t *CronTool) updateJob(ctx context.Context, args map[string]any) *ToolResu
 
 func (t *CronTool) canAccessJob(ctx context.Context, job *cron.CronJob) bool {
 	channel := ToolChannel(ctx)
-	chatID := ToolChatID(ctx)
-
-	// If no channel/chatID context, allow access (internal call)
-	if channel == "" && chatID == "" {
+	// Allow internal channels to bypass external access control
+	if constants.IsInternalChannel(channel) {
 		return true
 	}
-
-	// If channel/chatID are set, apply strict access control
+	chatID := ToolChatID(ctx)
+	// Deny if channel or chatID is missing (fail closed for security)
 	if channel == "" || chatID == "" {
 		return false
 	}

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -763,5 +764,240 @@ func TestCronTool_DisableJob_Success(t *testing.T) {
 	}
 	if !strings.Contains(disableResult.ForLLM, "disabled") {
 		t.Errorf("expected 'disabled' message, got: %s", disableResult.ForLLM)
+	}
+}
+
+// Test helper for creating cron jobs
+func addTestCronJob(t *testing.T, tool *CronTool, name, channel, chatID, command string) *cron.CronJob {
+	t.Helper()
+	everyMS := int64(60_000)
+	job, err := tool.cronService.AddJob(
+		name,
+		cron.CronSchedule{Kind: "every", EveryMS: &everyMS},
+		name+" message",
+		false, // deliver
+		channel,
+		chatID,
+	)
+	if err != nil {
+		t.Fatalf("AddJob() error: %v", err)
+	}
+	if command != "" {
+		job.Payload.Command = command
+		if err := tool.cronService.UpdateJob(job); err != nil {
+			t.Fatalf("UpdateJob() error: %v", err)
+		}
+	}
+	return job
+}
+
+// Helper to parse JSON result into CronJob
+func parseCronJobResult(t *testing.T, result *ToolResult) *cron.CronJob {
+	t.Helper()
+	var job *cron.CronJob
+	err := json.Unmarshal([]byte(result.ForLLM), &job)
+	if err != nil {
+		t.Fatalf("failed to parse job JSON: %v\nResult: %s", err, result.ForLLM)
+	}
+	return job
+}
+
+// Test case: allowlisted remote can access own command job
+func TestCronTool_AllowlistedRemoteCanAccessOwnCommandJob(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram:chat-1"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-1", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	listResult := tool.Execute(ctx, map[string]any{"action": "list"})
+	if listResult.IsError || !strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected list to include own command job, got: %+v", listResult)
+	}
+
+	getResult := tool.Execute(ctx, map[string]any{"action": "get", "job_id": job.ID})
+	if getResult.IsError {
+		t.Fatalf("expected get to access own command job, got: %s", getResult.ForLLM)
+	}
+	got := parseCronJobResult(t, getResult)
+	if got.ID != job.ID || got.Payload.Command != "df -h" {
+		t.Fatalf("get returned wrong command job: %+v", got)
+	}
+
+	updateResult := tool.Execute(ctx, map[string]any{
+		"action":  "update",
+		"job_id":  job.ID,
+		"message": "updated command description",
+	})
+	if updateResult.IsError {
+		t.Fatalf("expected update to access own command job, got: %s", updateResult.ForLLM)
+	}
+	updated := tool.cronService.GetJob(job.ID)
+	if updated.Payload.Message != "updated command description" || updated.Payload.Command != "df -h" {
+		t.Fatalf("update returned wrong command payload: %+v", updated.Payload)
+	}
+}
+
+// Test case: allowlisted remote cannot access other chat command job
+func TestCronTool_AllowlistedRemoteCannotAccessOtherChatCommandJob(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-2", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	listResult := tool.Execute(ctx, map[string]any{"action": "list"})
+	if listResult.IsError || strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected list to hide other chat command job, got: %+v", listResult)
+	}
+
+	for _, action := range []string{"get", "update"} {
+		args := map[string]any{"action": action, "job_id": job.ID}
+		if action == "update" {
+			args["message"] = "changed"
+		}
+		result := tool.Execute(ctx, args)
+		if !result.IsError || !strings.Contains(result.ForLLM, "not accessible") {
+			t.Fatalf("expected %s to reject other chat command job, got: %+v", action, result)
+		}
+	}
+}
+
+// Test case: non-allowlisted remote cannot access own command job
+func TestCronTool_NonAllowlistedRemoteCannotAccessOwnCommandJob(t *testing.T) {
+	tool := newTestCronTool(t)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-1", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	listResult := tool.Execute(ctx, map[string]any{"action": "list"})
+	if listResult.IsError || strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected list to hide non-allowlisted command job, got: %+v", listResult)
+	}
+
+	for _, action := range []string{"get", "update"} {
+		args := map[string]any{"action": action, "job_id": job.ID}
+		if action == "update" {
+			args["message"] = "changed"
+		}
+		result := tool.Execute(ctx, args)
+		if !result.IsError || !strings.Contains(result.ForLLM, "not accessible") {
+			t.Fatalf("expected %s to reject non-allowlisted command job, got: %+v", action, result)
+		}
+	}
+}
+
+// Test case: wildcard remote can access own command job
+func TestCronTool_WildcardRemoteCanAccessOwnCommandJob(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"*"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-1", "df -h")
+	other := addTestCronJob(t, tool, "other", "telegram", "chat-2", "uptime")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	listResult := tool.Execute(ctx, map[string]any{"action": "list"})
+	if listResult.IsError || !strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected wildcard list to include own command job, got: %+v", listResult)
+	}
+	if strings.Contains(listResult.ForLLM, other.ID) {
+		t.Fatalf("wildcard list should still hide other chat job, got: %s", listResult.ForLLM)
+	}
+
+	getResult := tool.Execute(ctx, map[string]any{"action": "get", "job_id": job.ID})
+	if getResult.IsError {
+		t.Fatalf("expected wildcard get to access own command job, got: %s", getResult.ForLLM)
+	}
+}
+
+// Test case: internal channel can access non-command jobs
+func TestCronTool_InternalChannelCanAccessNonCommandJob(t *testing.T) {
+	tool := newTestCronTool(t)
+	job := addTestCronJob(t, tool, "reminder", "cli", "direct", "")
+	ctx := WithToolContext(context.Background(), "cli", "direct")
+
+	listResult := tool.Execute(ctx, map[string]any{"action": "list"})
+	if listResult.IsError || !strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected list to include non-command job, got: %+v", listResult)
+	}
+
+	getResult := tool.Execute(ctx, map[string]any{"action": "get", "job_id": job.ID})
+	if getResult.IsError {
+		t.Fatalf("expected get to access non-command job, got: %s", getResult.ForLLM)
+	}
+}
+
+// Test case: remove job with access control
+func TestCronTool_RemoveJobWithAccessControl(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram:chat-1"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-1", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	removeResult := tool.Execute(ctx, map[string]any{"action": "remove", "job_id": job.ID})
+	if removeResult.IsError {
+		t.Fatalf("expected remove to succeed, got: %s", removeResult.ForLLM)
+	}
+
+	// Verify job is deleted
+	deleted := tool.cronService.GetJob(job.ID)
+	if deleted != nil {
+		t.Fatalf("expected job to be deleted")
+	}
+}
+
+// Test case: cannot remove job from different channel
+func TestCronTool_CannotRemoveJobFromDifferentChannel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram:chat-2"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-2", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	removeResult := tool.Execute(ctx, map[string]any{"action": "remove", "job_id": job.ID})
+	if !removeResult.IsError || !strings.Contains(removeResult.ForLLM, "not accessible") {
+		t.Fatalf("expected remove to be blocked, got: %+v", removeResult)
+	}
+
+	// Verify job still exists
+	stillExists := tool.cronService.GetJob(job.ID)
+	if stillExists == nil {
+		t.Fatalf("expected job to still exist")
+	}
+}
+
+// Test case: enable/disable with access control
+func TestCronTool_EnableDisableWithAccessControl(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram:chat-1"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-1", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	// Test enable
+	enableResult := tool.Execute(ctx, map[string]any{"action": "enable", "job_id": job.ID})
+	if enableResult.IsError {
+		t.Fatalf("expected enable to succeed, got: %s", enableResult.ForLLM)
+	}
+
+	// Test disable
+	disableResult := tool.Execute(ctx, map[string]any{"action": "disable", "job_id": job.ID})
+	if disableResult.IsError {
+		t.Fatalf("expected disable to succeed, got: %s", disableResult.ForLLM)
+	}
+}
+
+// Test case: cannot enable/disable job from different channel
+func TestCronTool_CannotEnableDisableFromDifferentChannel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Cron.CommandAllowedRemotes = []string{"telegram:chat-2"}
+	tool := newTestCronToolWithConfig(t, cfg)
+	job := addTestCronJob(t, tool, "command", "telegram", "chat-2", "df -h")
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+
+	// Test disable
+	disableResult := tool.Execute(ctx, map[string]any{"action": "disable", "job_id": job.ID})
+	if !disableResult.IsError || !strings.Contains(disableResult.ForLLM, "not accessible") {
+		t.Fatalf("expected disable to be blocked, got: %+v", disableResult)
 	}
 }

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -540,8 +540,8 @@ func TestCronTool_ListJobs_WithJobs(t *testing.T) {
 		t.Fatalf("failed to add job: %s", addResult.ForLLM)
 	}
 
-	// List jobs
-	listResult := tool.Execute(context.Background(), map[string]any{
+	// List jobs with the same context used to create them
+	listResult := tool.Execute(ctx, map[string]any{
 		"action": "list",
 	})
 
@@ -570,8 +570,8 @@ func TestCronTool_ListJobs_ShowsScheduleInfo(t *testing.T) {
 		t.Fatalf("failed to add job: %s", addResult.ForLLM)
 	}
 
-	// List jobs
-	listResult := tool.Execute(context.Background(), map[string]any{
+	// List jobs with the same context
+	listResult := tool.Execute(ctx, map[string]any{
 		"action": "list",
 	})
 
@@ -646,8 +646,8 @@ func TestCronTool_RemoveJob_Success(t *testing.T) {
 	}
 	jobID := jobs[0].ID
 
-	// Remove the job
-	removeResult := tool.Execute(context.Background(), map[string]any{
+	// Remove the job with the same context
+	removeResult := tool.Execute(ctx, map[string]any{
 		"action": "remove",
 		"job_id": jobID,
 	})
@@ -718,8 +718,8 @@ func TestCronTool_EnableJob_Success(t *testing.T) {
 	}
 	jobID := jobs[0].ID
 
-	// Enable the job
-	enableResult := tool.Execute(context.Background(), map[string]any{
+	// Enable the job with the same context
+	enableResult := tool.Execute(ctx, map[string]any{
 		"action": "enable",
 		"job_id": jobID,
 	})
@@ -753,8 +753,8 @@ func TestCronTool_DisableJob_Success(t *testing.T) {
 	}
 	jobID := jobs[0].ID
 
-	// Disable the job
-	disableResult := tool.Execute(context.Background(), map[string]any{
+	// Disable the job with the same context
+	disableResult := tool.Execute(ctx, map[string]any{
 		"action": "disable",
 		"job_id": jobID,
 	})
@@ -999,5 +999,35 @@ func TestCronTool_CannotEnableDisableFromDifferentChannel(t *testing.T) {
 	disableResult := tool.Execute(ctx, map[string]any{"action": "disable", "job_id": job.ID})
 	if !disableResult.IsError || !strings.Contains(disableResult.ForLLM, "not accessible") {
 		t.Fatalf("expected disable to be blocked, got: %+v", disableResult)
+	}
+}
+
+// Regression test: empty context must be denied access to command jobs
+func TestCronTool_EmptyContextDeniedForCommandJob(t *testing.T) {
+	tool := newTestCronTool(t)
+	job := addTestCronJob(t, tool, "command", "cli", "direct", "df -h")
+
+	// Empty context (no channel/chatID) should deny access, even though the job exists
+	emptyCtx := context.Background()
+
+	// Test get with empty context
+	getResult := tool.Execute(emptyCtx, map[string]any{"action": "get", "job_id": job.ID})
+	if !getResult.IsError || !strings.Contains(getResult.ForLLM, "not accessible") {
+		t.Fatalf("expected get with empty context to be denied for command job, got: %+v", getResult)
+	}
+
+	// Test list with empty context (should hide command job)
+	listResult := tool.Execute(emptyCtx, map[string]any{"action": "list"})
+	if listResult.IsError {
+		t.Fatalf("unexpected error on list: %s", listResult.ForLLM)
+	}
+	if strings.Contains(listResult.ForLLM, job.ID) {
+		t.Fatalf("expected list with empty context to hide command job, got: %s", listResult.ForLLM)
+	}
+
+	// Test remove with empty context
+	removeResult := tool.Execute(emptyCtx, map[string]any{"action": "remove", "job_id": job.ID})
+	if !removeResult.IsError || !strings.Contains(removeResult.ForLLM, "not accessible") {
+		t.Fatalf("expected remove with empty context to be denied, got: %+v", removeResult)
 	}
 }


### PR DESCRIPTION
## What this adds

Authorization for cron jobs invoked from remote channels, hand-ported from upstream `981ab3af`
(plus its genuine prerequisites `3056a540` and `1d8ef7dc`). Wave 2 of the v0.2.7..v0.3.1 sync.

A remote caller may now only see and mutate cron jobs belonging to its own channel and chat, and
**command** jobs additionally require the channel to be listed in a new
`tools.cron.command_allowed_remotes` allowlist.

| Commit | What |
|---|---|
| `395fe98c` | Cron access control + `CommandAllowedRemotes` config + `get`/`update` actions |

## Safety-relevant properties

**Fails closed.** `canAccessJob` grants a bypass only to an explicit internal channel
(`constants.IsInternalChannel` — `cli`, `system`, `subagent`) and otherwise **denies** any request
arriving without both a channel and a chat ID:

```go
if constants.IsInternalChannel(channel) { return true }
chatID := ToolChatID(ctx)
if channel == "" || chatID == "" { return false }   // fail closed
if job.Payload.Channel != channel || job.Payload.To != chatID { return false }
if job.Payload.Command != "" { return isCommandAllowedRemote(...) }
```

This matters: an earlier revision of this branch treated "no channel and no chat ID" as an internal
call and **returned true**, which would have granted full access — including to command jobs,
bypassing the allowlist — to any caller reaching this path without channel context. That was caught
in review and corrected to upstream's fail-closed shape. Five existing tests that relied on the
permissive behaviour were fixed to pass a real context, rather than the check being relaxed to suit
them.

**Prerequisites were ported rather than worked around.** `981ab3af` alone does not function without
`3056a540` (the `CommandAllowedRemotes` config) and `1d8ef7dc` (the `get`/`update` actions it
guards), so both are included.

## How it was tested

Ten authorization regression tests, including cross-channel denial for read, remove, and
enable/disable. Verified independently, including a **mutation test** on the security-critical branch:

```
# revert the guard to fail-open
if channel == "" || chatID == "" { return true }
→ TestCronTool_EmptyContextDeniedForCommandJob FAILS
# restored
→ PASS
```

Also green: `go generate ./...`, `go build ./...`, full `go test ./...` (0 failures, 3 consecutive
runs to rule out flakiness), `golangci-lint v2.10.1` (0 issues) — and again with the other three
wave-2 branches merged together.

## Known limitations

- `pkg/config/config.go` is touched (a `CommandAllowedRemotes` field on `CronToolsConfig`). It is
  required for the fix to function. It merges cleanly with the `AgentConfig.MCPServers` field added
  in #53 — different structs, different regions, verified by an integration merge.
- **The delegate tool was deliberately dropped from this PR.** It was implemented and tested, but
  nothing registers it (the wiring lives at `pkg/agent/loop.go:307-313`, outside this change's
  scope), so it would have shipped as unreachable code. It is preserved on the local branch
  `delegate-tool-preserved` (`f0688ff1`) for a follow-up that can own both packages and wire it properly.
- Upstream `8f8af087` (MCP session retry) was assessed as **already present** on `main` — verified by
  grep: `reconnectMu` (manager.go:125), `connectServerFunc` (:136, :267), `shouldReconnectCallError`
  (:498, :555). No work needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)