### PR TITLE
fix(web): harden launcher IP allowlist and trusted-proxy handling

### DIFF
--- a/web/backend/api/launcher_config.go
+++ b/web/backend/api/launcher_config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/cryptoquantumwave/khunquant/web/backend/launcherconfig"
 )
@@ -88,7 +87,6 @@ func (h *Handler) handleUpdateLauncherConfig(w http.ResponseWriter, r *http.Requ
 		cfg.AllowLocalhostBypass = *payload.AllowLocalhostBypass
 	}
 	cfg.TrustedProxyCIDRs = append([]string(nil), payload.TrustedProxyCIDRs...)
-	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
 	if err := launcherconfig.Validate(cfg); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/web/backend/api/launcher_config.go
+++ b/web/backend/api/launcher_config.go
@@ -4,14 +4,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cryptoquantumwave/khunquant/web/backend/launcherconfig"
 )
 
 type launcherConfigPayload struct {
-	Port         int      `json:"port"`
-	Public       bool     `json:"public"`
-	AllowedCIDRs []string `json:"allowed_cidrs"`
+	Port                 int      `json:"port"`
+	Public               bool     `json:"public"`
+	AllowedCIDRs         []string `json:"allowed_cidrs"`
+	AllowLocalhostBypass bool     `json:"allow_localhost_bypass"`
+	TrustedProxyCIDRs    []string `json:"trusted_proxy_cidrs"`
+}
+
+type launcherConfigUpdatePayload struct {
+	Port                 int      `json:"port"`
+	Public               bool     `json:"public"`
+	AllowedCIDRs         []string `json:"allowed_cidrs"`
+	AllowLocalhostBypass *bool    `json:"allow_localhost_bypass"`
+	TrustedProxyCIDRs    []string `json:"trusted_proxy_cidrs"`
 }
 
 func (h *Handler) registerLauncherConfigRoutes(mux *http.ServeMux) {
@@ -29,9 +40,11 @@ func (h *Handler) launcherFallbackConfig() launcherconfig.Config {
 		port = launcherconfig.DefaultPort
 	}
 	return launcherconfig.Config{
-		Port:         port,
-		Public:       h.serverPublic,
-		AllowedCIDRs: append([]string(nil), h.serverCIDRs...),
+		Port:                 port,
+		Public:               h.serverPublic,
+		AllowedCIDRs:         append([]string(nil), h.serverCIDRs...),
+		AllowLocalhostBypass: h.serverAllowLocalhostBypass,
+		TrustedProxyCIDRs:    append([]string(nil), h.serverTrustedProxyCIDRs...),
 	}
 }
 
@@ -48,31 +61,34 @@ func (h *Handler) handleGetLauncherConfig(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(launcherConfigPayload{
-		Port:         cfg.Port,
-		Public:       cfg.Public,
-		AllowedCIDRs: append([]string(nil), cfg.AllowedCIDRs...),
+		Port:                 cfg.Port,
+		Public:               cfg.Public,
+		AllowedCIDRs:         append([]string(nil), cfg.AllowedCIDRs...),
+		AllowLocalhostBypass: cfg.AllowLocalhostBypass,
+		TrustedProxyCIDRs:    append([]string(nil), cfg.TrustedProxyCIDRs...),
 	})
 }
 
 func (h *Handler) handleUpdateLauncherConfig(w http.ResponseWriter, r *http.Request) {
-	var payload launcherConfigPayload
+	var payload launcherConfigUpdatePayload
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	existing, err := h.loadLauncherConfig()
+	cfg, err := h.loadLauncherConfig()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to load launcher config: %v", err), http.StatusInternalServerError)
 		return
 	}
-
-	cfg := launcherconfig.Config{
-		Port:          payload.Port,
-		Public:        payload.Public,
-		AllowedCIDRs:  append([]string(nil), payload.AllowedCIDRs...),
-		LauncherToken: existing.LauncherToken,
+	cfg.Port = payload.Port
+	cfg.Public = payload.Public
+	cfg.AllowedCIDRs = append([]string(nil), payload.AllowedCIDRs...)
+	if payload.AllowLocalhostBypass != nil {
+		cfg.AllowLocalhostBypass = *payload.AllowLocalhostBypass
 	}
+	cfg.TrustedProxyCIDRs = append([]string(nil), payload.TrustedProxyCIDRs...)
+	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
 	if err := launcherconfig.Validate(cfg); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -85,8 +101,10 @@ func (h *Handler) handleUpdateLauncherConfig(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(launcherConfigPayload{
-		Port:         cfg.Port,
-		Public:       cfg.Public,
-		AllowedCIDRs: append([]string(nil), cfg.AllowedCIDRs...),
+		Port:                 cfg.Port,
+		Public:               cfg.Public,
+		AllowedCIDRs:         append([]string(nil), cfg.AllowedCIDRs...),
+		AllowLocalhostBypass: cfg.AllowLocalhostBypass,
+		TrustedProxyCIDRs:    append([]string(nil), cfg.TrustedProxyCIDRs...),
 	})
 }

--- a/web/backend/api/launcher_config_test.go
+++ b/web/backend/api/launcher_config_test.go
@@ -15,6 +15,7 @@ func TestGetLauncherConfigUsesRuntimeFallback(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	h := NewHandler(configPath)
 	h.SetServerOptions(19999, true, false, []string{"192.168.1.0/24"})
+	h.SetServerAccessOptions(false, []string{"10.0.0.0/8"})
 
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -37,10 +38,117 @@ func TestGetLauncherConfigUsesRuntimeFallback(t *testing.T) {
 	if len(got.AllowedCIDRs) != 1 || got.AllowedCIDRs[0] != "192.168.1.0/24" {
 		t.Fatalf("response allowed_cidrs = %v, want [192.168.1.0/24]", got.AllowedCIDRs)
 	}
+	if got.AllowLocalhostBypass {
+		t.Fatalf("response allow_localhost_bypass = true, want false")
+	}
+	if len(got.TrustedProxyCIDRs) != 1 || got.TrustedProxyCIDRs[0] != "10.0.0.0/8" {
+		t.Fatalf("response trusted_proxy_cidrs = %v, want [10.0.0.0/8]", got.TrustedProxyCIDRs)
+	}
 }
 
 func TestPutLauncherConfigPersists(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
+	path := launcherconfig.PathForAppConfig(configPath)
+	if err := launcherconfig.Save(
+		path,
+		launcherconfig.Config{
+			Port:                  18800,
+			Public:                false,
+			DashboardPasswordHash: "saved-hash",
+			LegacyLauncherToken:   "legacy-token",
+		},
+	); err != nil {
+		t.Fatalf("launcherconfig.Save() error = %v", err)
+	}
+	h := NewHandler(configPath)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/system/launcher-config",
+		strings.NewReader(`{"port":18080,"public":true,"allowed_cidrs":["192.168.1.0/24"],"allow_localhost_bypass":false,"trusted_proxy_cidrs":["10.0.0.0/8"]}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	cfg, err := launcherconfig.Load(path, launcherconfig.Default())
+	if err != nil {
+		t.Fatalf("launcherconfig.Load() error = %v", err)
+	}
+	if cfg.Port != 18080 || !cfg.Public {
+		t.Fatalf("saved config = %+v, want port=18080 public=true", cfg)
+	}
+	if cfg.DashboardPasswordHash != "saved-hash" {
+		t.Fatalf("saved dashboard_password_hash = %q, want saved-hash", cfg.DashboardPasswordHash)
+	}
+	if cfg.LegacyLauncherToken != "" {
+		t.Fatalf("saved legacy launcher_token = %q, want empty", cfg.LegacyLauncherToken)
+	}
+	if len(cfg.AllowedCIDRs) != 1 || cfg.AllowedCIDRs[0] != "192.168.1.0/24" {
+		t.Fatalf("saved config allowed_cidrs = %v, want [192.168.1.0/24]", cfg.AllowedCIDRs)
+	}
+	if cfg.AllowLocalhostBypass {
+		t.Fatalf("saved config allow_localhost_bypass = true, want false")
+	}
+	if len(cfg.TrustedProxyCIDRs) != 1 || cfg.TrustedProxyCIDRs[0] != "10.0.0.0/8" {
+		t.Fatalf("saved config trusted_proxy_cidrs = %v, want [10.0.0.0/8]", cfg.TrustedProxyCIDRs)
+	}
+}
+
+func TestPutLauncherConfigUsesDirectAccessFields(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	h := NewHandler(configPath)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/system/launcher-config",
+		strings.NewReader(`{"port":18080,"public":false,"allowed_cidrs":["192.168.1.0/24"],"allow_localhost_bypass":true,"trusted_proxy_cidrs":["10.0.0.0/8"]}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	path := launcherconfig.PathForAppConfig(configPath)
+	cfg, err := launcherconfig.Load(path, launcherconfig.Default())
+	if err != nil {
+		t.Fatalf("launcherconfig.Load() error = %v", err)
+	}
+	if !cfg.AllowLocalhostBypass {
+		t.Fatal("saved config allow_localhost_bypass = false, want true")
+	}
+	if len(cfg.TrustedProxyCIDRs) != 1 || cfg.TrustedProxyCIDRs[0] != "10.0.0.0/8" {
+		t.Fatalf("saved config trusted_proxy_cidrs = %v, want [10.0.0.0/8]", cfg.TrustedProxyCIDRs)
+	}
+}
+
+func TestPutLauncherConfigKeepsLocalhostBypassWhenOmitted(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	path := launcherconfig.PathForAppConfig(configPath)
+	if err := launcherconfig.Save(
+		path,
+		launcherconfig.Config{
+			Port:                 18800,
+			Public:               false,
+			AllowLocalhostBypass: true,
+			TrustedProxyCIDRs:    []string{"10.0.0.0/8"},
+		},
+	); err != nil {
+		t.Fatalf("launcherconfig.Save() error = %v", err)
+	}
 	h := NewHandler(configPath)
 
 	mux := http.NewServeMux()
@@ -59,54 +167,12 @@ func TestPutLauncherConfigPersists(t *testing.T) {
 		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 
-	path := launcherconfig.PathForAppConfig(configPath)
 	cfg, err := launcherconfig.Load(path, launcherconfig.Default())
 	if err != nil {
 		t.Fatalf("launcherconfig.Load() error = %v", err)
 	}
-	if cfg.Port != 18080 || !cfg.Public {
-		t.Fatalf("saved config = %+v, want port=18080 public=true", cfg)
-	}
-	if len(cfg.AllowedCIDRs) != 1 || cfg.AllowedCIDRs[0] != "192.168.1.0/24" {
-		t.Fatalf("saved config allowed_cidrs = %v, want [192.168.1.0/24]", cfg.AllowedCIDRs)
-	}
-}
-
-func TestPutLauncherConfigPreservesLauncherToken(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	launcherPath := launcherconfig.PathForAppConfig(configPath)
-	if err := launcherconfig.Save(launcherPath, launcherconfig.Config{
-		Port:          18800,
-		Public:        true,
-		AllowedCIDRs:  []string{"192.168.1.0/24"},
-		LauncherToken: "existing-token",
-	}); err != nil {
-		t.Fatalf("launcherconfig.Save() error = %v", err)
-	}
-
-	h := NewHandler(configPath)
-	mux := http.NewServeMux()
-	h.RegisterRoutes(mux)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPut,
-		"/api/system/launcher-config",
-		strings.NewReader(`{"port":18080,"public":true,"allowed_cidrs":["10.0.0.0/8"]}`),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	mux.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
-	}
-
-	cfg, err := launcherconfig.Load(launcherPath, launcherconfig.Default())
-	if err != nil {
-		t.Fatalf("launcherconfig.Load() error = %v", err)
-	}
-	if cfg.LauncherToken != "existing-token" {
-		t.Fatalf("launcher_token = %q, want %q", cfg.LauncherToken, "existing-token")
+	if !cfg.AllowLocalhostBypass {
+		t.Fatal("saved config allow_localhost_bypass = false, want true")
 	}
 }
 

--- a/web/backend/api/launcher_config_test.go
+++ b/web/backend/api/launcher_config_test.go
@@ -52,10 +52,8 @@ func TestPutLauncherConfigPersists(t *testing.T) {
 	if err := launcherconfig.Save(
 		path,
 		launcherconfig.Config{
-			Port:                  18800,
-			Public:                false,
-			DashboardPasswordHash: "saved-hash",
-			LegacyLauncherToken:   "legacy-token",
+			Port:   18800,
+			Public: false,
 		},
 	); err != nil {
 		t.Fatalf("launcherconfig.Save() error = %v", err)
@@ -84,12 +82,6 @@ func TestPutLauncherConfigPersists(t *testing.T) {
 	}
 	if cfg.Port != 18080 || !cfg.Public {
 		t.Fatalf("saved config = %+v, want port=18080 public=true", cfg)
-	}
-	if cfg.DashboardPasswordHash != "saved-hash" {
-		t.Fatalf("saved dashboard_password_hash = %q, want saved-hash", cfg.DashboardPasswordHash)
-	}
-	if cfg.LegacyLauncherToken != "" {
-		t.Fatalf("saved legacy launcher_token = %q, want empty", cfg.LegacyLauncherToken)
 	}
 	if len(cfg.AllowedCIDRs) != 1 || cfg.AllowedCIDRs[0] != "192.168.1.0/24" {
 		t.Fatalf("saved config allowed_cidrs = %v, want [192.168.1.0/24]", cfg.AllowedCIDRs)

--- a/web/backend/api/router.go
+++ b/web/backend/api/router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
@@ -10,15 +11,20 @@ import (
 
 // Handler serves HTTP API requests.
 type Handler struct {
-	configPath           string
-	serverPort           int
-	serverPublic         bool
-	serverPublicExplicit bool
-	serverCIDRs          []string
-	oauthMu              sync.Mutex
-	oauthFlows           map[string]*oauthFlow
-	oauthState           map[string]string
-	updateChecker        *updateChecker
+	configPath                 string
+	serverPort                 int
+	serverPublic               bool
+	serverPublicExplicit       bool
+	serverHostInput            string
+	serverHostExplicit         bool
+	serverCIDRs                []string
+	serverAllowLocalhostBypass bool
+	serverTrustedProxyCIDRs    []string
+	debug                      bool
+	oauthMu                    sync.Mutex
+	oauthFlows                 map[string]*oauthFlow
+	oauthState                 map[string]string
+	updateChecker              *updateChecker
 }
 
 // NewHandler creates an instance of the API handler.
@@ -26,11 +32,12 @@ func NewHandler(configPath string) *Handler {
 	uc := &updateChecker{}
 	uc.start(config.GetVersion())
 	return &Handler{
-		configPath:    configPath,
-		serverPort:    launcherconfig.DefaultPort,
-		oauthFlows:    make(map[string]*oauthFlow),
-		oauthState:    make(map[string]string),
-		updateChecker: uc,
+		configPath:                 configPath,
+		serverPort:                 launcherconfig.DefaultPort,
+		serverAllowLocalhostBypass: launcherconfig.Default().AllowLocalhostBypass,
+		oauthFlows:                 make(map[string]*oauthFlow),
+		oauthState:                 make(map[string]string),
+		updateChecker:              uc,
 	}
 }
 
@@ -40,6 +47,25 @@ func (h *Handler) SetServerOptions(port int, public bool, publicExplicit bool, a
 	h.serverPublic = public
 	h.serverPublicExplicit = publicExplicit
 	h.serverCIDRs = append([]string(nil), allowedCIDRs...)
+}
+
+func (h *Handler) SetServerAccessOptions(allowLocalhostBypass bool, trustedProxyCIDRs []string) {
+	h.serverAllowLocalhostBypass = allowLocalhostBypass
+	h.serverTrustedProxyCIDRs = append([]string(nil), trustedProxyCIDRs...)
+}
+
+// SetServerBindHost stores the launcher's effective bind host.
+// When explicit is true, hostInput is the normalized -host / PICOCLAW_LAUNCHER_HOST value.
+func (h *Handler) SetServerBindHost(hostInput string, explicit bool) {
+	h.serverHostInput = strings.TrimSpace(hostInput)
+	if !explicit {
+		h.serverHostInput = ""
+	}
+	h.serverHostExplicit = explicit
+}
+
+func (h *Handler) SetDebug(debug bool) {
+	h.debug = debug
 }
 
 // RegisterRoutes binds all API endpoint handlers to the ServeMux.

--- a/web/backend/launcherconfig/config.go
+++ b/web/backend/launcherconfig/config.go
@@ -14,19 +14,27 @@ const (
 	FileName = "launcher-config.json"
 	// DefaultPort is the default port for the web launcher.
 	DefaultPort = 18800
+	// EnvLauncherHost overrides launcher listen host.
+	EnvLauncherHost = "PICOCLAW_LAUNCHER_HOST"
 )
 
 // Config stores launch parameters for the web backend service.
 type Config struct {
-	Port          int      `json:"port"`
-	Public        bool     `json:"public"`
-	AllowedCIDRs  []string `json:"allowed_cidrs,omitempty"`
-	LauncherToken string   `json:"launcher_token,omitempty"`
+	Port                  int      `json:"port"`
+	Public                bool     `json:"public"`
+	AllowedCIDRs          []string `json:"allowed_cidrs,omitempty"`
+	AllowLocalhostBypass  bool     `json:"allow_localhost_bypass"`
+	TrustedProxyCIDRs     []string `json:"trusted_proxy_cidrs,omitempty"`
+	DashboardPasswordHash string   `json:"dashboard_password_hash,omitempty"`
+	LauncherToken         string   `json:"launcher_token,omitempty"`
+	// LegacyLauncherToken is read only for one-time migration from the removed
+	// token login flow. Save always clears it so new configs do not persist it.
+	LegacyLauncherToken string `json:"-"`
 }
 
 // Default returns default launcher settings.
 func Default() Config {
-	return Config{Port: DefaultPort, Public: false}
+	return Config{Port: DefaultPort, Public: false, AllowLocalhostBypass: true}
 }
 
 // Validate checks if launcher settings are valid.
@@ -37,6 +45,11 @@ func Validate(cfg Config) error {
 	for _, cidr := range cfg.AllowedCIDRs {
 		if _, _, err := net.ParseCIDR(cidr); err != nil {
 			return fmt.Errorf("invalid CIDR %q", cidr)
+		}
+	}
+	for _, cidr := range cfg.TrustedProxyCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("invalid trusted proxy CIDR %q", cidr)
 		}
 	}
 	return nil
@@ -90,6 +103,10 @@ func Load(path string, fallback Config) (Config, error) {
 		return Config{}, err
 	}
 	cfg.AllowedCIDRs = NormalizeCIDRs(cfg.AllowedCIDRs)
+	cfg.TrustedProxyCIDRs = NormalizeCIDRs(cfg.TrustedProxyCIDRs)
+	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
+	cfg.LauncherToken = strings.TrimSpace(cfg.LauncherToken)
+	cfg.LegacyLauncherToken = strings.TrimSpace(cfg.LegacyLauncherToken)
 	if err := Validate(cfg); err != nil {
 		return Config{}, err
 	}
@@ -99,6 +116,10 @@ func Load(path string, fallback Config) (Config, error) {
 // Save writes launcher settings to disk.
 func Save(path string, cfg Config) error {
 	cfg.AllowedCIDRs = NormalizeCIDRs(cfg.AllowedCIDRs)
+	cfg.TrustedProxyCIDRs = NormalizeCIDRs(cfg.TrustedProxyCIDRs)
+	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
+	cfg.LauncherToken = strings.TrimSpace(cfg.LauncherToken)
+	cfg.LegacyLauncherToken = ""
 	if err := Validate(cfg); err != nil {
 		return err
 	}

--- a/web/backend/launcherconfig/config.go
+++ b/web/backend/launcherconfig/config.go
@@ -20,16 +20,12 @@ const (
 
 // Config stores launch parameters for the web backend service.
 type Config struct {
-	Port                  int      `json:"port"`
-	Public                bool     `json:"public"`
-	AllowedCIDRs          []string `json:"allowed_cidrs,omitempty"`
-	AllowLocalhostBypass  bool     `json:"allow_localhost_bypass"`
-	TrustedProxyCIDRs     []string `json:"trusted_proxy_cidrs,omitempty"`
-	DashboardPasswordHash string   `json:"dashboard_password_hash,omitempty"`
-	LauncherToken         string   `json:"launcher_token,omitempty"`
-	// LegacyLauncherToken is read only for one-time migration from the removed
-	// token login flow. Save always clears it so new configs do not persist it.
-	LegacyLauncherToken string `json:"-"`
+	Port                 int      `json:"port"`
+	Public               bool     `json:"public"`
+	AllowedCIDRs         []string `json:"allowed_cidrs,omitempty"`
+	AllowLocalhostBypass bool     `json:"allow_localhost_bypass"`
+	TrustedProxyCIDRs    []string `json:"trusted_proxy_cidrs,omitempty"`
+	LauncherToken        string   `json:"launcher_token,omitempty"`
 }
 
 // Default returns default launcher settings.
@@ -104,9 +100,7 @@ func Load(path string, fallback Config) (Config, error) {
 	}
 	cfg.AllowedCIDRs = NormalizeCIDRs(cfg.AllowedCIDRs)
 	cfg.TrustedProxyCIDRs = NormalizeCIDRs(cfg.TrustedProxyCIDRs)
-	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
 	cfg.LauncherToken = strings.TrimSpace(cfg.LauncherToken)
-	cfg.LegacyLauncherToken = strings.TrimSpace(cfg.LegacyLauncherToken)
 	if err := Validate(cfg); err != nil {
 		return Config{}, err
 	}
@@ -117,9 +111,7 @@ func Load(path string, fallback Config) (Config, error) {
 func Save(path string, cfg Config) error {
 	cfg.AllowedCIDRs = NormalizeCIDRs(cfg.AllowedCIDRs)
 	cfg.TrustedProxyCIDRs = NormalizeCIDRs(cfg.TrustedProxyCIDRs)
-	cfg.DashboardPasswordHash = strings.TrimSpace(cfg.DashboardPasswordHash)
 	cfg.LauncherToken = strings.TrimSpace(cfg.LauncherToken)
-	cfg.LegacyLauncherToken = ""
 	if err := Validate(cfg); err != nil {
 		return err
 	}

--- a/web/backend/launcherconfig/config_test.go
+++ b/web/backend/launcherconfig/config_test.go
@@ -23,9 +23,13 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "launcher-config.json")
 	want := Config{
-		Port:         18080,
-		Public:       true,
-		AllowedCIDRs: []string{"192.168.1.0/24", "10.0.0.0/8"},
+		Port:                  18080,
+		Public:                true,
+		AllowedCIDRs:          []string{"192.168.1.0/24", "10.0.0.0/8"},
+		AllowLocalhostBypass:  false,
+		TrustedProxyCIDRs:     []string{"172.16.0.0/12"},
+		DashboardPasswordHash: "$2a$12$saved-dashboard-password-hash",
+		LegacyLauncherToken:   "legacy-token-should-not-persist",
 	}
 
 	if err := Save(path, want); err != nil {
@@ -38,12 +42,29 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	if got.Port != want.Port || got.Public != want.Public {
 		t.Fatalf("Load() = %+v, want %+v", got, want)
 	}
+	if got.AllowLocalhostBypass != want.AllowLocalhostBypass {
+		t.Fatalf("allow_localhost_bypass = %t, want %t", got.AllowLocalhostBypass, want.AllowLocalhostBypass)
+	}
+	if got.DashboardPasswordHash != want.DashboardPasswordHash {
+		t.Fatalf("dashboard_password_hash = %q, want %q", got.DashboardPasswordHash, want.DashboardPasswordHash)
+	}
+	if got.LegacyLauncherToken != "" {
+		t.Fatalf("legacy launcher_token = %q, want empty after Save", got.LegacyLauncherToken)
+	}
 	if len(got.AllowedCIDRs) != len(want.AllowedCIDRs) {
 		t.Fatalf("allowed_cidrs len = %d, want %d", len(got.AllowedCIDRs), len(want.AllowedCIDRs))
 	}
 	for i := range want.AllowedCIDRs {
 		if got.AllowedCIDRs[i] != want.AllowedCIDRs[i] {
 			t.Fatalf("allowed_cidrs[%d] = %q, want %q", i, got.AllowedCIDRs[i], want.AllowedCIDRs[i])
+		}
+	}
+	if len(got.TrustedProxyCIDRs) != len(want.TrustedProxyCIDRs) {
+		t.Fatalf("trusted_proxy_cidrs len = %d, want %d", len(got.TrustedProxyCIDRs), len(want.TrustedProxyCIDRs))
+	}
+	for i := range want.TrustedProxyCIDRs {
+		if got.TrustedProxyCIDRs[i] != want.TrustedProxyCIDRs[i] {
+			t.Fatalf("trusted_proxy_cidrs[%d] = %q, want %q", i, got.TrustedProxyCIDRs[i], want.TrustedProxyCIDRs[i])
 		}
 	}
 
@@ -72,6 +93,16 @@ func TestValidateRejectsInvalidCIDR(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Validate() expected error for invalid CIDR")
+	}
+}
+
+func TestValidateRejectsInvalidTrustedProxyCIDR(t *testing.T) {
+	err := Validate(Config{
+		Port:              18800,
+		TrustedProxyCIDRs: []string{"10.0.0.0/8", "invalid-cidr"},
+	})
+	if err == nil {
+		t.Fatal("Validate() expected error for invalid trusted proxy CIDR")
 	}
 }
 

--- a/web/backend/launcherconfig/config_test.go
+++ b/web/backend/launcherconfig/config_test.go
@@ -23,13 +23,11 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "launcher-config.json")
 	want := Config{
-		Port:                  18080,
-		Public:                true,
-		AllowedCIDRs:          []string{"192.168.1.0/24", "10.0.0.0/8"},
-		AllowLocalhostBypass:  false,
-		TrustedProxyCIDRs:     []string{"172.16.0.0/12"},
-		DashboardPasswordHash: "$2a$12$saved-dashboard-password-hash",
-		LegacyLauncherToken:   "legacy-token-should-not-persist",
+		Port:                 18080,
+		Public:               true,
+		AllowedCIDRs:         []string{"192.168.1.0/24", "10.0.0.0/8"},
+		AllowLocalhostBypass: false,
+		TrustedProxyCIDRs:    []string{"172.16.0.0/12"},
 	}
 
 	if err := Save(path, want); err != nil {
@@ -44,12 +42,6 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	}
 	if got.AllowLocalhostBypass != want.AllowLocalhostBypass {
 		t.Fatalf("allow_localhost_bypass = %t, want %t", got.AllowLocalhostBypass, want.AllowLocalhostBypass)
-	}
-	if got.DashboardPasswordHash != want.DashboardPasswordHash {
-		t.Fatalf("dashboard_password_hash = %q, want %q", got.DashboardPasswordHash, want.DashboardPasswordHash)
-	}
-	if got.LegacyLauncherToken != "" {
-		t.Fatalf("legacy launcher_token = %q, want empty after Save", got.LegacyLauncherToken)
 	}
 	if len(got.AllowedCIDRs) != len(want.AllowedCIDRs) {
 		t.Fatalf("allowed_cidrs len = %d, want %d", len(got.AllowedCIDRs), len(want.AllowedCIDRs))

--- a/web/backend/main.go
+++ b/web/backend/main.go
@@ -140,12 +140,17 @@ func main() {
 	// API Routes (e.g. /api/status)
 	apiHandler := api.NewHandler(absPath)
 	apiHandler.SetServerOptions(portNum, effectivePublic, explicitPublic, launcherCfg.AllowedCIDRs)
+	apiHandler.SetServerAccessOptions(launcherCfg.AllowLocalhostBypass, launcherCfg.TrustedProxyCIDRs)
 	apiHandler.RegisterRoutes(mux)
 
 	// Frontend Embedded Assets
 	registerEmbedRoutes(mux)
 
-	accessControlledMux, err := middleware.IPAllowlist(launcherCfg.AllowedCIDRs, mux)
+	accessControlledMux, err := middleware.IPAllowlist(middleware.IPAllowlistConfig{
+		AllowedCIDRs:         launcherCfg.AllowedCIDRs,
+		AllowLocalhostBypass: launcherCfg.AllowLocalhostBypass,
+		TrustedProxyCIDRs:    launcherCfg.TrustedProxyCIDRs,
+	}, mux)
 	if err != nil {
 		log.Fatalf("Invalid allowed CIDR configuration: %v", err)
 	}

--- a/web/backend/middleware/access_control.go
+++ b/web/backend/middleware/access_control.go
@@ -41,9 +41,7 @@ func IPAllowlist(cfg IPAllowlistConfig, next http.Handler) (http.Handler, error)
 
 		ip := peerIP
 		if containsIP(trustedProxyNets, peerIP) {
-			if forwardedIP := clientIPFromXForwardedFor(r.Header.Get("X-Forwarded-For")); forwardedIP != nil {
-				ip = forwardedIP
-			}
+			ip = clientIPFromXForwardedFor(r.Header.Get("X-Forwarded-For"), trustedProxyNets, peerIP)
 		}
 
 		if cfg.AllowLocalhostBypass && ip.IsLoopback() {
@@ -88,16 +86,34 @@ func clientIPFromRemoteAddr(remoteAddr string) net.IP {
 	return net.ParseIP(host)
 }
 
-func clientIPFromXForwardedFor(header string) net.IP {
-	first, _, _ := strings.Cut(header, ",")
-	first = strings.Trim(strings.TrimSpace(first), `"`)
-	if first == "" {
+func clientIPFromXForwardedFor(header string, trustedProxyNets []*net.IPNet, fallback net.IP) net.IP {
+	parts := strings.Split(header, ",")
+	ips := make([]net.IP, 0, len(parts))
+	for _, part := range parts {
+		if ip := parseIPToken(part); ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+	if len(ips) == 0 {
+		return fallback
+	}
+	for i := len(ips) - 1; i >= 0; i-- {
+		if !containsIP(trustedProxyNets, ips[i]) {
+			return ips[i]
+		}
+	}
+	return ips[0]
+}
+
+func parseIPToken(raw string) net.IP {
+	token := strings.Trim(strings.TrimSpace(raw), `"`)
+	if token == "" {
 		return nil
 	}
-	if ip := net.ParseIP(first); ip != nil {
+	if ip := net.ParseIP(token); ip != nil {
 		return ip
 	}
-	if host, _, err := net.SplitHostPort(first); err == nil {
+	if host, _, err := net.SplitHostPort(token); err == nil {
 		return net.ParseIP(host)
 	}
 	return nil

--- a/web/backend/middleware/access_control.go
+++ b/web/backend/middleware/access_control.go
@@ -7,42 +7,77 @@ import (
 	"strings"
 )
 
+// IPAllowlistConfig controls launcher network access decisions.
+type IPAllowlistConfig struct {
+	AllowedCIDRs         []string
+	AllowLocalhostBypass bool
+	TrustedProxyCIDRs    []string
+}
+
 // IPAllowlist restricts access to requests from configured CIDR ranges.
-// Loopback addresses are always allowed for local administration.
+// Loopback addresses can optionally bypass CIDR checks for local administration.
+// X-Forwarded-For is only trusted when the immediate peer is in a trusted CIDR.
 // Empty CIDR list means no restriction.
-func IPAllowlist(allowedCIDRs []string, next http.Handler) (http.Handler, error) {
-	if len(allowedCIDRs) == 0 {
+func IPAllowlist(cfg IPAllowlistConfig, next http.Handler) (http.Handler, error) {
+	allowedNets, err := parseCIDRNets(cfg.AllowedCIDRs)
+	if err != nil {
+		return nil, err
+	}
+	trustedProxyNets, err := parseCIDRNets(cfg.TrustedProxyCIDRs)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(allowedNets) == 0 {
 		return next, nil
 	}
 
-	nets := make([]*net.IPNet, 0, len(allowedCIDRs))
-	for _, cidr := range allowedCIDRs {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerIP := clientIPFromRemoteAddr(r.RemoteAddr)
+		if peerIP == nil {
+			rejectByPolicy(w, r)
+			return
+		}
+
+		ip := peerIP
+		if containsIP(trustedProxyNets, peerIP) {
+			if forwardedIP := clientIPFromXForwardedFor(r.Header.Get("X-Forwarded-For")); forwardedIP != nil {
+				ip = forwardedIP
+			}
+		}
+
+		if cfg.AllowLocalhostBypass && ip.IsLoopback() {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if containsIP(allowedNets, ip) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		rejectByPolicy(w, r)
+	}), nil
+}
+
+func parseCIDRNets(cidrs []string) ([]*net.IPNet, error) {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
 		}
 		nets = append(nets, ipNet)
 	}
+	return nets, nil
+}
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := clientIPFromRemoteAddr(r.RemoteAddr)
-		if ip == nil {
-			rejectByPolicy(w, r)
-			return
+func containsIP(nets []*net.IPNet, ip net.IP) bool {
+	for _, ipNet := range nets {
+		if ipNet.Contains(ip) {
+			return true
 		}
-		if ip.IsLoopback() {
-			next.ServeHTTP(w, r)
-			return
-		}
-		for _, ipNet := range nets {
-			if ipNet.Contains(ip) {
-				next.ServeHTTP(w, r)
-				return
-			}
-		}
-
-		rejectByPolicy(w, r)
-	}), nil
+	}
+	return false
 }
 
 func clientIPFromRemoteAddr(remoteAddr string) net.IP {
@@ -51,6 +86,21 @@ func clientIPFromRemoteAddr(remoteAddr string) net.IP {
 		host = h
 	}
 	return net.ParseIP(host)
+}
+
+func clientIPFromXForwardedFor(header string) net.IP {
+	first, _, _ := strings.Cut(header, ",")
+	first = strings.Trim(strings.TrimSpace(first), `"`)
+	if first == "" {
+		return nil
+	}
+	if ip := net.ParseIP(first); ip != nil {
+		return ip
+	}
+	if host, _, err := net.SplitHostPort(first); err == nil {
+		return net.ParseIP(host)
+	}
+	return nil
 }
 
 func rejectByPolicy(w http.ResponseWriter, r *http.Request) {

--- a/web/backend/middleware/access_control_test.go
+++ b/web/backend/middleware/access_control_test.go
@@ -130,7 +130,7 @@ func TestIPAllowlist_IgnoresXForwardedForFromUntrustedPeer(t *testing.T) {
 func TestIPAllowlist_UsesXForwardedForFromTrustedPeer(t *testing.T) {
 	h, err := IPAllowlist(IPAllowlistConfig{
 		AllowedCIDRs:      []string{"192.168.1.0/24"},
-		TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+		TrustedProxyCIDRs: []string{"10.0.0.0/8", "203.0.113.0/24"},
 	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/web/backend/middleware/access_control_test.go
+++ b/web/backend/middleware/access_control_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestIPAllowlist_EmptyCIDRsAllowsAll(t *testing.T) {
-	h, err := IPAllowlist(nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h, err := IPAllowlist(IPAllowlistConfig{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	if err != nil {
@@ -25,7 +25,9 @@ func TestIPAllowlist_EmptyCIDRsAllowsAll(t *testing.T) {
 }
 
 func TestIPAllowlist_RejectsOutsideCIDR(t *testing.T) {
-	h, err := IPAllowlist([]string{"192.168.1.0/24"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs: []string{"192.168.1.0/24"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	if err != nil {
@@ -43,7 +45,9 @@ func TestIPAllowlist_RejectsOutsideCIDR(t *testing.T) {
 }
 
 func TestIPAllowlist_AllowsInsideCIDR(t *testing.T) {
-	h, err := IPAllowlist([]string{"192.168.1.0/24"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs: []string{"192.168.1.0/24"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	if err != nil {
@@ -60,8 +64,11 @@ func TestIPAllowlist_AllowsInsideCIDR(t *testing.T) {
 	}
 }
 
-func TestIPAllowlist_AlwaysAllowsLoopback(t *testing.T) {
-	h, err := IPAllowlist([]string{"192.168.1.0/24"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestIPAllowlist_AllowsLoopbackWhenBypassEnabled(t *testing.T) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs:         []string{"192.168.1.0/24"},
+		AllowLocalhostBypass: true,
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	if err != nil {
@@ -78,8 +85,74 @@ func TestIPAllowlist_AlwaysAllowsLoopback(t *testing.T) {
 	}
 }
 
+func TestIPAllowlist_RejectsLoopbackWhenBypassDisabled(t *testing.T) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs: []string{"192.168.1.0/24"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	if err != nil {
+		t.Fatalf("IPAllowlist() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestIPAllowlist_IgnoresXForwardedForFromUntrustedPeer(t *testing.T) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs:      []string{"192.168.1.0/24"},
+		TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	if err != nil {
+		t.Fatalf("IPAllowlist() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:1234"
+	req.Header.Set("X-Forwarded-For", "192.168.1.88")
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestIPAllowlist_UsesXForwardedForFromTrustedPeer(t *testing.T) {
+	h, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs:      []string{"192.168.1.0/24"},
+		TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	if err != nil {
+		t.Fatalf("IPAllowlist() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.8:1234"
+	req.Header.Set("X-Forwarded-For", "192.168.1.88, 203.0.113.5")
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
 func TestIPAllowlist_InvalidCIDR(t *testing.T) {
-	_, err := IPAllowlist([]string{"bad-cidr"}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := IPAllowlist(IPAllowlistConfig{
+		AllowedCIDRs: []string{"bad-cidr"},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	if err == nil {
 		t.Fatal("IPAllowlist() expected error for invalid CIDR")
 	}


### PR DESCRIPTION
## What this adds

Hardening for the launcher dashboard's network access control, hand-ported from upstream
`52ab6c46` and `01760135`. Wave 2 of the v0.2.7..v0.3.1 sync.

| Commit | What |
|---|---|
| `aad379af` | `AllowLocalhostBypass` + `TrustedProxyCIDRs`; middleware takes an `IPAllowlistConfig` struct instead of a bare `[]string` |
| `1f609864` | X-Forwarded-For is parsed by walking the proxy chain and taking the first address **not** in `TrustedProxyCIDRs` |

## Safety-relevant properties

**Spoofed `X-Forwarded-For` is ignored from untrusted peers.** Previously the header was not
consulted against a trusted-proxy set; now a client that simply sets the header cannot present itself
as an allowlisted address. This is the case `TestIPAllowlist_IgnoresXForwardedForFromUntrustedPeer`
pins.

**Localhost access is now explicit.** It was unconditional; it is now governed by
`AllowLocalhostBypass`, so a deployment can gate loopback if it wants to.

**No behavioural change by default** — existing configs keep working; the new fields are additive.

## What was deliberately NOT included

**Upstream `f53222f6` (`POST /api/config/reset`) is not in this PR.** That endpoint wipes
configuration to defaults, and in this fork it would be protected by IP address alone: our password
authentication layer is not ported. A config-wipe callable by any host on an allowed LAN subnet, with
no authentication, is not a trade worth making. Upstream ships it only because upstream has the full
password-auth flow wired.

**`DashboardPasswordHash` was removed from this branch.** An earlier revision stored it but never
verified it. A config field with that name which nothing checks is worse than absent — an operator
would set a dashboard password and believe the dashboard was protected. Password auth is therefore
**not implemented** here, and that is stated plainly rather than implied away.

One correction worth recording, since it was asserted during development and is false: this fork does
**not** have a wide-open networked default. `web/backend/main.go:112` already refuses to start:
```go
if effectivePublic && len(launcherCfg.AllowedCIDRs) == 0 {
    log.Fatalf("Refusing to start in public mode without an IP allowlist...")
}
```
So the deployment is either localhost-only or has an explicit allowlist. The reset endpoint is still
correctly excluded, but on the accurate grounds above.

## How it was tested

Four targeted allowlist tests, including both directions of the proxy question:
`TestIPAllowlist_IgnoresXForwardedForFromUntrustedPeer`,
`TestIPAllowlist_UsesXForwardedForFromTrustedPeer`,
`TestIPAllowlist_RejectsLoopbackWhenBypassDisabled`,
`TestIPAllowlist_AllowsLoopbackWhenBypassEnabled`.

Verified independently: `go generate ./...`, `go build ./...`, full `go test ./...` (0 failures),
`golangci-lint v2.10.1` (0 issues) — and again with the other three wave-2 branches merged together.

## Known limitations

- **No password authentication.** Access control here is network-level only (IP allowlist +
  trusted-proxy parsing). Porting upstream's password auth — and only then the config-reset endpoint —
  is a follow-up. `golang.org/x/crypto/bcrypt` is already in `go.mod`, so that work needs no new dependency.
- `web/backend/main.go` is touched because the middleware signature changed; no other change owns that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)