### PR TITLE
feat(web,api): model catalog, provider model fetch, and connectivity test

### DIFF
--- a/web/backend/api/model_catalog.go
+++ b/web/backend/api/model_catalog.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/fileutil"
+)
+
+// CatalogModel represents a single model entry in a saved catalog.
+type CatalogModel struct {
+	ID      string         `json:"id"`
+	OwnedBy string         `json:"owned_by,omitempty"`
+	Extra   map[string]any `json:"extra,omitempty"`
+}
+
+// CatalogEntry is a saved list of upstream models fetched for a specific provider+key combination.
+type CatalogEntry struct {
+	ID         string         `json:"id"`
+	Provider   string         `json:"provider"`
+	APIBase    string         `json:"api_base"`
+	APIKeyMask string         `json:"api_key_mask"`
+	Models     []CatalogModel `json:"models"`
+	FetchedAt  string         `json:"fetched_at"`
+}
+
+// CatalogStore holds all saved model catalogs.
+type CatalogStore struct {
+	Entries map[string]*CatalogEntry `json:"entries"`
+}
+
+func catalogFilePath() string {
+	return filepath.Join(config.HomeDir(), "model_catalogs.json")
+}
+
+// generateCatalogKey creates a deterministic key for a provider+base+key combination.
+func generateCatalogKey(provider, apiBase, apiKey string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	apiBase = strings.TrimRight(strings.TrimSpace(apiBase), "/")
+	hash := sha256.Sum256([]byte(apiKey))
+	return fmt.Sprintf("%s|%s|%x", provider, apiBase, hash[:6])
+}
+
+// maskAPIKeyValue masks an API key for display.
+// Keys longer than 12 chars show prefix + last 4 chars: "sk-****abcd".
+// Keys 9-12 chars show prefix + last 2 chars: "sk-****cd".
+// Shorter keys are fully masked as "****".
+// Empty keys return empty string.
+// Ensure at least 40% of the key will not be displayed.
+func maskAPIKeyValue(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	if len(key) <= 8 {
+		return "****"
+	}
+	if len(key) <= 12 {
+		return key[:3] + "****" + key[len(key)-2:]
+	}
+	return key[:3] + "****" + key[len(key)-4:]
+}
+
+func loadCatalogs() (*CatalogStore, error) {
+	path := catalogFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &CatalogStore{Entries: make(map[string]*CatalogEntry)}, nil
+		}
+		return nil, err
+	}
+	var store CatalogStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, err
+	}
+	if store.Entries == nil {
+		store.Entries = make(map[string]*CatalogEntry)
+	}
+	return &store, nil
+}
+
+func saveCatalogs(store *CatalogStore) error {
+	path := catalogFilePath()
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.WriteFileAtomic(path, data, 0o600)
+}
+
+// SaveCatalog persists a fetched model list for a given provider+key combination.
+// If a catalog with the same key already exists, it is updated.
+func SaveCatalog(provider, apiBase, apiKey string, models []CatalogModel) error {
+	store, err := loadCatalogs()
+	if err != nil {
+		return err
+	}
+	key := generateCatalogKey(provider, apiBase, apiKey)
+	store.Entries[key] = &CatalogEntry{
+		ID:         key,
+		Provider:   strings.ToLower(strings.TrimSpace(provider)),
+		APIBase:    strings.TrimRight(strings.TrimSpace(apiBase), "/"),
+		APIKeyMask: maskAPIKeyValue(apiKey),
+		Models:     models,
+		FetchedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	return saveCatalogs(store)
+}
+
+// handleListCatalogs returns all saved model catalogs.
+//
+//	GET /api/models/catalog
+func (h *Handler) handleListCatalogs(w http.ResponseWriter, r *http.Request) {
+	store, err := loadCatalogs()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to load catalogs: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	entries := make([]*CatalogEntry, 0, len(store.Entries))
+	for _, e := range store.Entries {
+		entries = append(entries, e)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"entries": entries,
+		"total":   len(entries),
+	})
+}
+
+// handleDeleteCatalog deletes a saved model catalog by ID.
+//
+//	DELETE /api/models/catalog/{id}
+func (h *Handler) handleDeleteCatalog(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	store, err := loadCatalogs()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to load catalogs: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if _, ok := store.Entries[id]; !ok {
+		http.Error(w, "catalog not found", http.StatusNotFound)
+		return
+	}
+
+	delete(store.Entries, id)
+	if err := saveCatalogs(store); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to save catalogs: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/web/backend/api/model_catalog_test.go
+++ b/web/backend/api/model_catalog_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskAPIKeyValue(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "empty key",
+			key:  "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			key:  "   ",
+			want: "",
+		},
+		{
+			name: "short key fully masked",
+			key:  "abcd",
+			want: "****",
+		},
+		{
+			name: "length 8 boundary fully masked",
+			key:  "12345678",
+			want: "****",
+		},
+		{
+			name: "length 9 boundary shows last 2",
+			key:  "123456789",
+			want: "123****89",
+		},
+		{
+			name: "length 10 shows last 2",
+			key:  "1234567890",
+			want: "123****90",
+		},
+		{
+			name: "length 12 boundary shows last 2",
+			key:  "abcdefghijkl",
+			want: "abc****kl",
+		},
+		{
+			name: "length 13 boundary shows last 4",
+			key:  "abcdefghijklm",
+			want: "abc****jklm",
+		},
+		{
+			name: "typical api key",
+			key:  "sk-1234567890abcd",
+			want: "sk-****abcd",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskAPIKeyValue(tc.key)
+			if got != tc.want {
+				t.Fatalf("maskAPIKeyValue(%q) = %q, want %q", tc.key, got, tc.want)
+			}
+
+			if tc.key != "" {
+				displayed := strings.Replace(got, "****", "", 1)
+				if len(strings.TrimSpace(tc.key)) <= 8 {
+					if displayed != "" {
+						t.Fatalf("maskAPIKeyValue(%q) displayed part = %q, want empty", tc.key, displayed)
+					}
+				} else {
+					if len(displayed)*10 > len(strings.TrimSpace(tc.key))*6 {
+						t.Fatalf(
+							"maskAPIKeyValue(%q) displayed length = %d, want at most 60%% of %d",
+							tc.key,
+							len(displayed),
+							len(strings.TrimSpace(tc.key)),
+						)
+					}
+				}
+			}
+		})
+	}
+}

--- a/web/backend/api/models.go
+++ b/web/backend/api/models.go
@@ -1,15 +1,33 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
+	"github.com/cryptoquantumwave/khunquant/pkg/providers"
 )
+
+// fetchableProviders lists providers that support OpenAI-compatible /models listing.
+var fetchableProviders = map[string]bool{
+	"openai": true, "deepseek": true, "openrouter": true,
+	"qwen-portal": true, "qwen-intl": true, "moonshot": true,
+	"volcengine": true, "zhipu": true, "groq": true,
+	"mistral": true, "nvidia": true, "cerebras": true,
+	"venice": true, "shengsuanyun": true, "vivgrid": true,
+	"minimax": true, "longcat": true, "modelscope": true,
+	"mimo": true, "avian": true, "zai": true, "novita": true,
+	"litellm": true, "vllm": true, "lmstudio": true, "ollama": true,
+}
 
 // registerModelRoutes binds model list management endpoints to the ServeMux.
 func (h *Handler) registerModelRoutes(mux *http.ServeMux) {
@@ -18,6 +36,11 @@ func (h *Handler) registerModelRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/models/default", h.handleSetDefaultModel)
 	mux.HandleFunc("PUT /api/models/{index}", h.handleUpdateModel)
 	mux.HandleFunc("DELETE /api/models/{index}", h.handleDeleteModel)
+	mux.HandleFunc("POST /api/models/fetch", h.handleFetchModels)
+	mux.HandleFunc("GET /api/models/catalog", h.handleListCatalogs)
+	mux.HandleFunc("DELETE /api/models/catalog/{id}", h.handleDeleteCatalog)
+	mux.HandleFunc("POST /api/models/{index}/test", h.handleTestModel)
+	mux.HandleFunc("POST /api/models/test-inline", h.handleTestInlineModel)
 }
 
 // modelResponse is the JSON structure returned for each model in the list.
@@ -323,4 +346,433 @@ func maskAPIKey(key string) string {
 
 	// Show first 3 chars and last 4 chars
 	return key[:3] + "****" + key[len(key)-4:]
+}
+
+// handleFetchModels fetches available models from an upstream provider.
+//
+//	POST /api/models/fetch
+func (h *Handler) handleFetchModels(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var req struct {
+		Provider   string `json:"provider"`
+		APIKey     string `json:"api_key"`
+		APIBase    string `json:"api_base"`
+		ModelIndex *int   `json:"model_index,omitempty"`
+	}
+	if err = json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if req.Provider == "" {
+		http.Error(w, "provider is required", http.StatusBadRequest)
+		return
+	}
+
+	if !fetchableProviders[strings.ToLower(req.Provider)] {
+		http.Error(w, fmt.Sprintf("provider %q does not support model listing", req.Provider), http.StatusBadRequest)
+		return
+	}
+
+	apiKey := strings.TrimSpace(req.APIKey)
+	apiBase := strings.TrimSpace(req.APIBase)
+
+	if apiKey == "" && req.ModelIndex != nil {
+		if stored := h.lookupStoredAPIKey(*req.ModelIndex, req.Provider, apiBase); stored != "" {
+			apiKey = stored
+		}
+	}
+
+	if apiBase == "" {
+		// Resolve default API base for the provider
+		tempConfig := &config.ModelConfig{Model: req.Provider + "/dummy"}
+		apiBase = providers.ResolveAPIBase(tempConfig)
+	}
+	if apiBase == "" {
+		http.Error(w, fmt.Sprintf("No default API base for provider %q", req.Provider), http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	models, err := fetchUpstreamModels(ctx, req.Provider, apiBase, apiKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to fetch models: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	// Auto-save fetched models to catalog
+	catalogModels := make([]CatalogModel, len(models))
+	for i, m := range models {
+		catalogModels[i] = CatalogModel{ID: m.ID, OwnedBy: m.OwnedBy}
+	}
+	if saveErr := SaveCatalog(req.Provider, apiBase, apiKey, catalogModels); saveErr != nil {
+		// Log but don't fail the request — saving catalog is non-critical
+		logger.WarnF("Failed to save model catalog: %v", map[string]any{"error": saveErr})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"models": models,
+		"total":  len(models),
+	})
+}
+
+func (h *Handler) lookupStoredAPIKey(index int, reqProvider, reqAPIBase string) string {
+	cfg, err := config.LoadConfig(h.configPath)
+	if err != nil || index < 0 || index >= len(cfg.ModelList) {
+		return ""
+	}
+	stored := cfg.ModelList[index]
+	storedProvider, _ := providers.ExtractProtocol(stored.Model)
+	if providers.NormalizeProvider(reqProvider) != providers.NormalizeProvider(storedProvider) {
+		return ""
+	}
+	effectiveReqBase := strings.TrimSpace(reqAPIBase)
+	if effectiveReqBase == "" {
+		tempConfig := &config.ModelConfig{Model: reqProvider + "/dummy"}
+		effectiveReqBase = providers.ResolveAPIBase(tempConfig)
+	}
+	effectiveStoredBase := strings.TrimSpace(stored.APIBase)
+	if effectiveStoredBase == "" {
+		effectiveStoredBase = providers.ResolveAPIBase(&stored)
+	}
+	if normalizeAPIBaseForCompare(effectiveReqBase) != normalizeAPIBaseForCompare(effectiveStoredBase) {
+		return ""
+	}
+	return stored.APIKey.String()
+}
+
+// normalizeAPIBaseForCompare normalizes an API base URL for equality comparison
+// by trimming trailing slashes and lowering the scheme/host.
+func normalizeAPIBaseForCompare(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	raw = strings.TrimRight(raw, "/")
+	u, err := url.Parse(raw)
+	if err != nil {
+		return strings.ToLower(raw)
+	}
+	if u.Host == "" {
+		u, err = url.Parse("//" + raw)
+		if err != nil {
+			return strings.ToLower(raw)
+		}
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimRight(u.Path, "/")
+}
+
+type upstreamModel struct {
+	ID      string `json:"id"`
+	OwnedBy string `json:"owned_by,omitempty"`
+}
+
+func fetchUpstreamModels(ctx context.Context, provider, apiBase, apiKey string) ([]upstreamModel, error) {
+	apiBase = strings.TrimRight(strings.TrimSpace(apiBase), "/")
+
+	var fetchURL string
+	switch strings.ToLower(provider) {
+	case "ollama":
+		// Strip /v1 suffix if present to get the Ollama root
+		root := apiBase
+		if strings.HasSuffix(root, "/v1") {
+			root = root[:len(root)-3]
+		}
+		root = strings.TrimRight(root, "/")
+		fetchURL = root + "/api/tags"
+		return fetchOllamaModels(ctx, fetchURL)
+	default:
+		// OpenAI-compatible: /v1/models
+		fetchURL = apiBase + "/models"
+		return fetchOpenAICompatibleModels(ctx, fetchURL, apiKey)
+	}
+}
+
+func fetchOpenAICompatibleModels(ctx context.Context, fetchURL, apiKey string) ([]upstreamModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	type modelItem struct {
+		ID      string `json:"id"`
+		OwnedBy string `json:"owned_by"`
+	}
+
+	// {"data": [...]} envelope. Distinguish "envelope shape with empty list"
+	// from "object without a data key" via Data being non-nil after unmarshal:
+	// json.Unmarshal sets Data to []modelItem{} for `{"data":[]}` but leaves
+	// it as nil when "data" is absent or null.
+	var envelope struct {
+		Data []modelItem `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Data != nil {
+		models := make([]upstreamModel, 0, len(envelope.Data))
+		for _, m := range envelope.Data {
+			if m.ID != "" {
+				models = append(models, upstreamModel{ID: m.ID, OwnedBy: m.OwnedBy})
+			}
+		}
+		return models, nil
+	}
+
+	// Bare-array shape, including `[]`.
+	var arr []modelItem
+	if err := json.Unmarshal(body, &arr); err == nil {
+		models := make([]upstreamModel, 0, len(arr))
+		for _, m := range arr {
+			if m.ID != "" {
+				models = append(models, upstreamModel{ID: m.ID, OwnedBy: m.OwnedBy})
+			}
+		}
+		return models, nil
+	}
+
+	preview := body
+	if len(preview) > 256 {
+		preview = preview[:256]
+	}
+	return nil, fmt.Errorf("decode response: unrecognized shape: %s", strings.TrimSpace(string(preview)))
+}
+
+func fetchOllamaModels(ctx context.Context, fetchURL string) ([]upstreamModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama returned status %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Models []struct {
+			Name  string `json:"name"`
+			Model string `json:"model"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	models := make([]upstreamModel, 0, len(parsed.Models))
+	for _, m := range parsed.Models {
+		id := m.Name
+		if id == "" {
+			id = m.Model
+		}
+		if id != "" {
+			models = append(models, upstreamModel{ID: id})
+		}
+	}
+	return models, nil
+}
+
+// handleTestModel tests connectivity to a model endpoint.
+//
+//	POST /api/models/{index}/test
+func (h *Handler) handleTestModel(w http.ResponseWriter, r *http.Request) {
+	idx, err := strconv.Atoi(r.PathValue("index"))
+	if err != nil {
+		http.Error(w, "Invalid index", http.StatusBadRequest)
+		return
+	}
+
+	cfg, err := config.LoadConfig(h.configPath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to load config: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if idx < 0 || idx >= len(cfg.ModelList) {
+		http.Error(w, fmt.Sprintf("Index %d out of range (0-%d)", idx, len(cfg.ModelList)-1), http.StatusNotFound)
+		return
+	}
+
+	m := cfg.ModelList[idx]
+	start := time.Now()
+	summary := modelConfigurationStatus(m)
+	latency := time.Since(start).Milliseconds()
+
+	result := map[string]any{
+		"success":    summary.Available,
+		"latency_ms": latency,
+		"status":     summary.Status,
+	}
+
+	if !summary.Available {
+		if summary.Status == modelStatusUnconfigured {
+			result["error"] = "API key not configured"
+		} else {
+			result["error"] = "Endpoint unreachable"
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// handleTestInlineModel tests connectivity using inline (unsaved) parameters.
+// Unlike handleTestModel which only checks saved config, this endpoint performs
+// a real network probe (e.g. GET /models) to verify the endpoint is reachable.
+//
+//	POST /api/models/test-inline
+func (h *Handler) handleTestInlineModel(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var req struct {
+		Provider   string `json:"provider"`
+		Model      string `json:"model"`
+		APIBase    string `json:"api_base"`
+		APIKey     string `json:"api_key"`
+		AuthMethod string `json:"auth_method"`
+		ModelIndex *int   `json:"model_index"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Build the Model field from provider and model ID
+	modelStr := strings.TrimSpace(req.Model)
+	providerStr := strings.TrimSpace(req.Provider)
+	if providerStr != "" && !strings.Contains(modelStr, "/") {
+		modelStr = providerStr + "/" + modelStr
+	}
+
+	m := &config.ModelConfig{
+		Model:      modelStr,
+		APIBase:    strings.TrimSpace(req.APIBase),
+		AuthMethod: strings.TrimSpace(req.AuthMethod),
+	}
+	if req.APIKey != "" {
+		m.APIKey = *config.NewSecureString(req.APIKey)
+	}
+
+	// When api_key is empty and model_index is provided, fall back to stored credentials.
+	// This lets the edit form test unsaved field changes while using the saved key.
+	// Only reuse the stored key when the provider and effective API base match
+	// the saved model, to prevent attaching a credential to a different endpoint.
+	if req.APIKey == "" && req.ModelIndex != nil {
+		cfg, err := config.LoadConfig(h.configPath)
+		if err == nil && *req.ModelIndex >= 0 && *req.ModelIndex < len(cfg.ModelList) {
+			stored := cfg.ModelList[*req.ModelIndex]
+			storedProvider, _ := providers.ExtractProtocol(stored.Model)
+			reqProvider, _ := providers.ExtractProtocol(m.Model)
+			providerMatch := reqProvider == "" || reqProvider == providers.NormalizeProvider(storedProvider)
+
+			effectiveReqBase := strings.TrimSpace(m.APIBase)
+			if effectiveReqBase == "" {
+				effectiveReqBase = providers.ResolveAPIBase(m)
+			}
+			effectiveStoredBase := strings.TrimSpace(stored.APIBase)
+			if effectiveStoredBase == "" {
+				effectiveStoredBase = providers.ResolveAPIBase(&stored)
+			}
+			baseMatch := normalizeAPIBaseForCompare(effectiveReqBase) == normalizeAPIBaseForCompare(effectiveStoredBase)
+
+			if providerMatch && baseMatch {
+				if stored.APIKey.String() != "" {
+					m.APIKey = stored.APIKey
+				}
+				if m.APIBase == "" && stored.APIBase != "" {
+					m.APIBase = stored.APIBase
+				}
+			}
+		}
+	}
+
+	// Check if configuration exists
+	if !hasModelConfiguration(*m) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"success":    false,
+			"latency_ms": 0,
+			"status":     modelStatusUnconfigured,
+			"error":      "API key not configured",
+		})
+		return
+	}
+
+	// Perform a real network probe
+	start := time.Now()
+	available := probeModelConnectivity(m)
+	latency := time.Since(start).Milliseconds()
+
+	result := map[string]any{
+		"success":    available,
+		"latency_ms": latency,
+	}
+	if available {
+		result["status"] = modelStatusAvailable
+	} else {
+		result["status"] = modelStatusUnreachable
+		result["error"] = "Endpoint unreachable"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// probeModelConnectivity performs a real network probe to verify model endpoint reachability.
+func probeModelConnectivity(m *config.ModelConfig) bool {
+	apiBase := modelProbeAPIBase(*m)
+	protocol, modelID := splitModel(m.Model)
+
+	switch protocol {
+	case "ollama":
+		return probeOllamaModelFunc(apiBase, modelID)
+	case "vllm", "lmstudio":
+		return probeOpenAICompatibleModelFunc(apiBase, modelID, m.APIKey.String())
+	case "github-copilot", "copilot":
+		return probeTCPServiceFunc(apiBase)
+	case "claude-cli", "claudecli", "codex-cli", "codexcli":
+		// CLI-based providers are always reachable if installed
+		return true
+	default:
+		// For remote providers (OpenAI, Anthropic, Gemini, DeepSeek, etc.),
+		// make a real GET /models request to verify connectivity and credentials.
+		if apiBase != "" {
+			return probeOpenAICompatibleModelFunc(apiBase, modelID, m.APIKey.String())
+		}
+		return false
+	}
 }

--- a/web/backend/api/models_test.go
+++ b/web/backend/api/models_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -448,5 +449,282 @@ func TestHandleUpdateModel_UpdatesAPIKey(t *testing.T) {
 	}
 	if got := newCfg.ModelList[0].APIKey.String(); got != "new_api_key" {
 		t.Errorf("APIKey = %q, want new_api_key", got)
+	}
+}
+
+func TestFetchOpenAICompatibleModels_ResponseShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		apiKey    string
+		wantLen   int
+		wantFirst struct {
+			id, ownedBy string
+		}
+		wantSecond struct {
+			id, ownedBy string
+		}
+	}{
+		{
+			name:     "envelope shape",
+			response: `{"data":[{"id":"gpt-4o","owned_by":"openai"},{"id":"gpt-4o-mini","owned_by":"openai"}]}`,
+			apiKey:   "test-key",
+			wantLen:  2,
+			wantFirst: struct {
+				id, ownedBy string
+			}{id: "gpt-4o", ownedBy: "openai"},
+			wantSecond: struct {
+				id, ownedBy string
+			}{id: "gpt-4o-mini", ownedBy: "openai"},
+		},
+		{
+			name:     "bare array shape",
+			response: `[{"id":"qwen-max","owned_by":"qwen"},{"id":"qwen-plus","owned_by":"qwen"}]`,
+			apiKey:   "",
+			wantLen:  2,
+			wantFirst: struct {
+				id, ownedBy string
+			}{id: "qwen-max", ownedBy: "qwen"},
+			wantSecond: struct {
+				id, ownedBy string
+			}{id: "qwen-plus", ownedBy: "qwen"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tt.response)
+			}))
+			defer srv.Close()
+
+			models, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", tt.apiKey)
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+			if len(models) != tt.wantLen {
+				t.Fatalf("len(models) = %d, want %d", len(models), tt.wantLen)
+			}
+			if models[0].ID != tt.wantFirst.id || models[0].OwnedBy != tt.wantFirst.ownedBy {
+				t.Fatalf("models[0] = %+v, want {ID:%s OwnedBy:%s}", models[0], tt.wantFirst.id, tt.wantFirst.ownedBy)
+			}
+			if models[1].ID != tt.wantSecond.id || models[1].OwnedBy != tt.wantSecond.ownedBy {
+				t.Fatalf("models[1] = %+v, want {ID:%s OwnedBy:%s}", models[1], tt.wantSecond.id, tt.wantSecond.ownedBy)
+			}
+		})
+	}
+}
+
+func TestFetchOpenAICompatibleModels_EmptyEnvelopeReturnsEmptySlice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer srv.Close()
+
+	models, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", "k")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("len(models) = %d, want 0", len(models))
+	}
+}
+
+func TestFetchOpenAICompatibleModels_EmptyBareArrayReturnsEmptySlice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	models, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", "k")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("len(models) = %d, want 0", len(models))
+	}
+}
+
+func TestFetchOpenAICompatibleModels_UnrecognizedShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"models":[],"error":"unsupported"}`)
+	}))
+	defer srv.Close()
+
+	_, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", "k")
+	if err == nil {
+		t.Fatal("error = nil, want unrecognized shape error")
+	}
+	if !strings.Contains(err.Error(), "unrecognized shape") {
+		t.Fatalf("error = %q, want it to contain 'unrecognized shape'", err.Error())
+	}
+}
+
+func TestFetchOpenAICompatibleModels_FiltersEmptyIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[`+
+			`{"id":"gpt-4o","owned_by":"openai"},`+
+			`{"id":"","owned_by":"openai"},`+
+			`{"id":"gpt-4o-mini"}]}`)
+	}))
+	defer srv.Close()
+
+	models, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", "k")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2 (empty IDs should be filtered)", len(models))
+	}
+	if models[0].ID != "gpt-4o" {
+		t.Fatalf("models[0].ID = %q, want %q", models[0].ID, "gpt-4o")
+	}
+	if models[1].ID != "gpt-4o-mini" {
+		t.Fatalf("models[1].ID = %q, want %q", models[1].ID, "gpt-4o-mini")
+	}
+}
+
+func TestFetchOpenAICompatibleModels_SetsAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[{"id":"m1"}]}`)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", "my-secret-key"); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if gotAuth != "Bearer my-secret-key" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer my-secret-key")
+	}
+}
+
+func TestFetchOpenAICompatibleModels_NoAuthHeaderWhenKeyEmpty(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id":"m1"}]`)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchOpenAICompatibleModels(t.Context(), srv.URL+"/models", ""); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty", gotAuth)
+	}
+}
+
+func TestHandleFetchModels_ModelIndexUsesStoredKey(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[{"id":"gpt-4o","owned_by":"openai"}]}`)
+	}))
+	defer srv.Close()
+
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.ModelList = []config.ModelConfig{
+		{
+			ModelName: "my-openai",
+			Model:     "openai/gpt-4o",
+			APIBase:   srv.URL,
+			APIKey:    *config.NewSecureString("sk-stored-secret"),
+		},
+	}
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	idx := 0
+	body := fmt.Sprintf(`{"provider":"openai","api_base":"%s","model_index":%d}`, srv.URL, idx)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/models/fetch", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if gotAuth != "Bearer sk-stored-secret" {
+		t.Fatalf("Authorization = %q, want stored key to be used", gotAuth)
+	}
+
+	var resp struct {
+		Models []upstreamModel `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if len(resp.Models) != 1 || resp.Models[0].ID != "gpt-4o" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestHandleFetchModels_ModelIndexProviderMismatchRejectsKey(t *testing.T) {
+	requestReceivedWithAuth := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			requestReceivedWithAuth = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer srv.Close()
+
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.ModelList = []config.ModelConfig{
+		{
+			ModelName: "my-openai",
+			Model:     "openai/gpt-4o",
+			APIBase:   "https://api.openai.com/v1",
+			APIKey:    *config.NewSecureString("sk-openai-secret"),
+		},
+	}
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := fmt.Sprintf(`{"provider":"groq","api_base":"%s","model_index":0}`, srv.URL)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/models/fetch", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if requestReceivedWithAuth {
+		t.Fatal("stored openai key should NOT be sent to mismatched provider (groq)")
 	}
 }


### PR DESCRIPTION
## What this adds

Backend API for fetching a provider's model list, saving it as a catalog, and verifying connectivity
before a model is saved. Hand-ported from upstream `f6190b54`, `30938df4`, `604187e3`. Wave 2 of the
v0.2.7..v0.3.1 sync.

| Commit | What |
|---|---|
| `d0b49683` | Catalog store, list/delete endpoints, API-key masking |
| `0ca7d049` | Fetch models from a provider; reuse stored credentials; real connectivity probe |

Five endpoints, live via `registerModelRoutes()` → `RegisterRoutes()` → `web/backend/main.go:143`:

| Method | Path |
|---|---|
| `GET` | `/api/models/catalog` |
| `DELETE` | `/api/models/catalog/{id}` |
| `POST` | `/api/models/fetch` |
| `POST` | `/api/models/{index}/test` |
| `POST` | `/api/models/test-inline` |

Usable today, e.g. `curl http://127.0.0.1:8000/api/models/catalog`.

## Safety-relevant properties

- **API keys are masked** on display (`maskAPIKeyValue`), with tests covering length boundaries.
- **Stored credentials are only reused after the provider and API base both match** — `lookupStoredAPIKey`
  compares normalized API bases so a request cannot induce the server to send a saved key to a
  different endpoint. `TestHandleFetchModels_ModelIndexProviderMismatchRejectsKey` pins this.
- Adapted to this fork's `ModelConfig`, where the protocol is embedded in `Model` (e.g.
  `openai/gpt-4o`) and extracted via `providers.ExtractProtocol` — upstream's separate `Provider`
  field does not exist here.
- **No live network calls in tests**; everything uses `httptest`, including the connectivity-probe
  feature's own tests. No real API keys.

## How it was tested

Backend tests cover both response envelope shapes (`{"data": [...]}` and a bare array), empty and
unrecognized shapes, empty-ID filtering, Authorization header presence and absence, and stored-key
reuse including the mismatch-rejection case above.

Verified independently: `go generate ./...`, `go build ./...`, full `go test ./...` (0 failures),
`golangci-lint v2.10.1` (0 issues) — and again with the other three wave-2 branches merged together.

## Known limitations

- **Backend only — the frontend is not ported.** Upstream's commits also change
  `web/frontend/src/components/models/*`, but this fork's UI is rebranded and carries fork-only
  screens (delta-neutral dashboard, exchanges config, Webull/Settrade broker config). Porting those
  components blind risked broad rewrites of diverged code for the lowest-priority item in the wave.
  The endpoints are fully reachable without it, so this ships as a usable API and the UI is a genuine
  follow-up rather than a missing dependency.
- Two commits rather than upstream's three, because the `models.go` changes from `30938df4` and
  `604187e3` are interdependent once hand-ported. All three upstream SHAs are cited in the bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)