### PR TITLE
docs: correct upstream sync status and document security posture

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Upstream picoclaw implements OS-level process confinement for child processes vi
 - **Windows**: Restricted tokens, low-integrity level, and Job Objects limit what a child process can access or do.
 
 **khunquant does not have OS-level isolation, and never did.** Our fork point (2026-03-15) predates upstream's addition of `pkg/isolation` (2026-04-08, commit `51eecde0`). Adopting it would require:
-- 27 call sites across `exec.Command` across 17 non-test files to route through an isolation layer.
+- 27 `exec.Command` call sites across 17 non-test files to route through an isolation layer.
 - Linux deployment to require `bwrap` on the PATH — a poor fit for the $10-device / Raspberry Pi Zero target.
 - A macOS stub (`platform_other.go`) providing no isolation, leaving that platform entirely unprotected.
 
@@ -47,6 +47,8 @@ The deny-list catches common attack patterns in the command string:
 ### Access Control Model
 
 The web launcher (`web/backend`) implements **IP-address-based access control only**. There is **no password authentication**.
+
+*Status: password authentication is not implemented on `main` as of this document. Work to add it is in progress; this section must be updated in the same change that lands it.*
 
 Protection consists of:
 1. **IP allowlist**: A CIDR allowlist in `launcher-config.json` (field `allowed_cidrs`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Posture
+
+This document describes khunquant's security architecture and known limitations. Our goal is transparency: we aim to help operators understand what risks are or are not mitigated by the current design.
+
+## Subprocess Execution — No OS-Level Isolation
+
+### The Isolation Gap
+
+Upstream picoclaw implements OS-level process confinement for child processes via `pkg/isolation`:
+- **Linux**: `bwrap` (Bubblewrap) creates a confined namespace with filesystem restrictions, capability dropping, resource limits, and network isolation.
+- **Windows**: Restricted tokens, low-integrity level, and Job Objects limit what a child process can access or do.
+
+**khunquant does not have OS-level isolation, and never did.** Our fork point (2026-03-15) predates upstream's addition of `pkg/isolation` (2026-04-08, commit `51eecde0`). Adopting it would require:
+- 27 call sites across `exec.Command` across 17 non-test files to route through an isolation layer.
+- Linux deployment to require `bwrap` on the PATH — a poor fit for the $10-device / Raspberry Pi Zero target.
+- A macOS stub (`platform_other.go`) providing no isolation, leaving that platform entirely unprotected.
+
+**If subprocess confinement is operationally required, this fork is not suitable.**
+
+### Our Defense: Regex-Based Deny-List
+
+The sole defence against subprocess risks is a regex deny-list defined in `pkg/tools/shell.go` (`defaultDenyPatterns` and platform-specific `windowsDenyPatterns`). The guard function `guardCommand` validates user-supplied commands before execution.
+
+This layer **structurally cannot provide**:
+- **Filesystem confinement**: The regex inspects the command string only; it does not resolve symlinks, does not prevent path traversal via relative paths or environment variables, and does not forbid writes to files outside the workspace.
+- **Resource limits**: No CPU time, memory, or I/O quotas. A command can exhaust system resources.
+- **Capability dropping**: Process retains all capabilities of its parent. It can bind to privileged ports, modify kernel state, or load kernel modules if the parent can.
+- **PID/namespace isolation**: The child process is visible in the same PID namespace; it can signal or inspect sibling processes.
+- **Network-egress restriction**: There is no firewall or proxy; the child process can connect to any network address the parent can reach.
+
+### What the Regex Layer Blocks
+
+The deny-list catches common attack patterns in the command string:
+- Recursive deletion (`rm -rf`, `del /f`), disk formatting (`format`, `mkfs`, `dd if=`), and writes to block devices.
+- Shell metacharacters that would spawn sub-shells (`$()`, `` ` ``, `|`, heredocs).
+- PowerShell encoding schemes (`-EncodedCommand`, `[Text.Encoding]`, `.GetString`, `FromBase64String`).
+- Privilege escalation (`sudo`, `chmod`, `chown`, `kill`).
+- Package manager operations (`apt`, `yum`, `npm -g`, `pip --user`), container ops, and git push.
+
+**The regex layer can be bypassed** by:
+- Obfuscating commands in environment variables or files written by prior steps.
+- Using lesser-known commands not on the deny-list (e.g., `shred`, `srm`, `dd bs=` with a different argument order).
+- Exploiting parser bugs in the regex engine or shell itself (e.g., Unicode normalization, locale-specific character classes).
+
+## Launcher Dashboard — Network-Level Access Control Only
+
+### Access Control Model
+
+The web launcher (`web/backend`) implements **IP-address-based access control only**. There is **no password authentication**.
+
+Protection consists of:
+1. **IP allowlist**: A CIDR allowlist in `launcher-config.json` (field `allowed_cidrs`).
+2. **Trusted-proxy X-Forwarded-For parsing**: If the launcher is behind a reverse proxy (e.g., nginx), it can extract the client IP from the `X-Forwarded-For` header if the proxy's IP is in `trusted_proxy_cidrs`.
+
+### Fail-Closed Guard
+
+The launcher refuses to start in public mode (listening on `0.0.0.0`) without an explicit allowlist. The guard is in `web/backend/main.go`, lines 113–119:
+
+```go
+// Refuse to start in public mode without an explicit CIDR allowlist — the
+// IP allowlist is the only network-level boundary for LAN access.
+if effectivePublic && len(launcherCfg.AllowedCIDRs) == 0 {
+	log.Fatalf(
+		"Refusing to start in public mode without an IP allowlist.\n" +
+			"Add allowed_cidrs to launcher-config.json (e.g. \"192.168.1.0/24\") or\n" +
+			"remove the -public flag to restrict access to localhost only.",
+	)
+}
+```
+
+If no allowlist is provided, the process exits with an error.
+
+### Known Limitations
+
+- **Spoofed or missing X-Forwarded-For**: If the reverse proxy is misconfigured or omits the header, the launcher may fall back to the proxy's own IP, allowing unintended clients to access the dashboard.
+- **No per-user authentication**: Any client whose IP matches the allowlist can perform any operation (modify config, restart agents, etc.). There is no credential prompt.
+- **No audit log**: Access is not logged by user or timestamp (though the launcher does emit structured logs).
+- **HTTPS not enforced**: The launcher does not require TLS for connections. Credentials or session tokens would be transmitted in plaintext over HTTP.
+
+### Upstream's Deliberate Non-Port
+
+The upstream codebase includes a `POST /api/config/reset` endpoint that clears the entire configuration. **We intentionally did not port this endpoint**, because without password authentication it would be a configuration wipe protected by IP address alone — an unacceptable risk for a shared network.
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in khunquant, please report it via a private GitHub security advisory on this repository. Do not open a public issue or pull request.
+
+To file a security advisory:
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Describe the issue, impact, and recommended fix.
+
+The maintainers will assess the report and coordinate a fix and disclosure timeline.

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -2,6 +2,55 @@
 
 khunquant is a fork of [picoclaw](https://github.com/sipeed/picoclaw).
 
+## Sync Status Overview
+
+Our fork point is `96fd4e05` (2026-03-15), before upstream added OS-level process isolation (`pkg/isolation`, commit `51eecde0`, 2026-04-08).
+
+### Upstream Coverage (commit-subject overlap measured against our `main`)
+
+The following table shows how many upstream non-merge commits in each range have equivalent subjects in our repository:
+
+| upstream range | non-merge commits | present in our `main` | coverage |
+|---|---|---|---|
+| merge-base `96fd4e05` .. v0.2.6 | 457 | 130 | 28% |
+| v0.2.6 .. v0.2.7 | 164 | 38 | 23% |
+| v0.2.7 .. v0.2.8 | 86 | 6 | 6% |
+| v0.2.8 .. v0.2.9 | 172 | 4 | 2% |
+| v0.2.9 .. v0.3.0 | 137 | 4 | 2% |
+| v0.3.0 .. v0.3.1 | 52 | 0 | 0% |
+
+Roughly **453 of 621** non-merge commits below v0.2.7 never landed, and that range remains **unexamined** for selective cherry-pick opportunities.
+
+### Sync Waves
+
+#### Wave 1: Foundation & Hardening (PRs #49-#52)
+
+These four PRs landed critical fixes and features from upstream's post-fork development (v0.2.7 onwards):
+
+| PR | Commit | Subject | Notes |
+|---|---|---|---|
+| #49 | `a822230b` | fix(deps): bump Go to 1.25.13 for 6 stdlib CVEs | Address multiple stdlib security issues |
+| #50 | `4e3ea97d` | fix(tools): harden exec guard against PowerShell encoding bypass | Shell-guard improvements: encoding bypass, scheme-less URLs, workspace-relative paths |
+| #51 | `ce4ca2af` | fix(channels,seahorse,web): port upstream correctness fixes from picoclaw v0.2.8-v0.3.1 | Correctness fixes across channels, seahorse, web, and build |
+| #52 | `34f03c34` | feat(voice): multi-backend voice transcription | Whisper, ElevenLabs, audio-model backends |
+
+#### Wave 2: Access Control & Infrastructure (PRs #53-#56)
+
+These four PRs add authorization and connectivity features:
+
+| PR | Commit | Subject | Notes |
+|---|---|---|---|
+| #53 | `929e3ac3` | feat(agent,config): restrict which MCP servers an agent may load | Per-agent MCP server allowlist |
+| #54 | `520dc287` | fix(tools): scope remote cron command access | Remote cron command authorization |
+| #55 | `facff706` | fix(web): harden launcher IP allowlist and trusted-proxy handling | IP allowlist and trusted-proxy hardening |
+| #56 | `3175061a` | feat(web,api): model catalog, provider model fetch, and connectivity test | Model catalog and provider connectivity API |
+
+### Tag Namespace Hazard
+
+**Our tags collide by name with upstream tags.** Specifically, our own tags `v0.3.0-rc.1`, `v0.3.1-rc.1`, `v0.3.2-rc.1`, and `v0.3.3-rc.*` (April 2026) share the same names as upstream's release versions `v0.3.0`, `v0.3.1`, `v0.3.2`, and `v0.3.3`.
+
+When comparing commits against upstream, **always use 8-character SHAs instead of tag names** to avoid ambiguity. Tag-based comparisons will pull the wrong commit.
+
 ## v0.2.6 → v0.2.7 (synced 2026-04-25)
 
 Base: picoclaw tag `v0.2.6`  


### PR DESCRIPTION
## What this adds

Two documentation corrections that record things the codebase currently gets wrong or leaves unsaid.

| Commit | What |
|---|---|
| `1c5397a6` | Correct `UPSTREAM_SYNC.md`; record sync waves 1 and 2 |
| `fd9f8f05` | Add `SECURITY.md` documenting subprocess-isolation and dashboard-auth posture |
| `a60af34f` | Typo fix + forward-looking status note |

## Why

**`UPSTREAM_SYNC.md` overstated our position.** It documented a single v0.2.6 → v0.2.7 campaign and
read as though the fork were level with upstream v0.2.7. Measured by commit-subject overlap against
`main`:

| upstream range | non-merge commits | present in our `main` |
|---|---|---|
| merge-base `96fd4e05` .. v0.2.6 | 457 | 130 (28%) |
| v0.2.6 .. v0.2.7 | 164 | 38 (23%) |
| v0.2.7 .. v0.2.8 | 86 | 6 (6%) |
| v0.2.8 .. v0.2.9 | 172 | 4 (2%) |
| v0.2.9 .. v0.3.0 | 137 | 4 (2%) |
| v0.3.0 .. v0.3.1 | 52 | 0 (0%) |

Roughly **453 of 621** non-merge commits below v0.2.7 never landed, and that range is still
unexamined. This document had already misled planning once; it now states the real position, records
what waves 1 and 2 actually landed, and warns about the tag-namespace hazard (our `v0.3.x-rc.N` tags
collide by name with upstream's `v0.3.x` releases, so comparisons must use SHAs).

**`SECURITY.md` did not exist.** It now documents two gaps plainly, so nobody assumes protection that
is not there:

- **No OS-level subprocess isolation.** Upstream has `pkg/isolation` (bwrap on Linux; restricted
  token + low integrity + Job Object on Windows). We do not, and never did — upstream added it in
  `51eecde0` (2026-04-08), after our 2026-03-15 fork point. Our `pkg/sandbox` is **not** the
  equivalent despite the name: it is a mock-exchange HTTP server for paper trading. The real defence
  on that path is the regex deny-list in `pkg/tools/shell.go`, and the document states what a regex
  layer structurally cannot do.
- **Dashboard access control is network-level only** — IP allowlist plus trusted-proxy handling; no
  password authentication. It also records that the process fails closed
  (`web/backend/main.go:113-119` refuses to start in public mode without an explicit CIDR allowlist),
  and why upstream's `POST /api/config/reset` was deliberately not ported.

## How it was verified

Every factual claim was checked against the tree by the author **and independently re-checked** before
approval — the `main.go` line range (113–119 is exactly the `if` block through its closing brace), the
27 `exec.Command` call sites across 17 non-test files, the absence of `pkg/isolation`, the
`pkg/sandbox/doc.go` description, and all eight wave-1/wave-2 merge SHAs against `origin/main`.

Markdown only — no code changes.

## Known limitations

- The "no password authentication" statement is true of `main` as of this PR, but that work is in
  progress on a parallel branch. Rather than pre-announce a feature that does not exist, the section
  carries an explicit note that it **must be updated in the same change that lands password auth** —
  and that follow-up PR will be held to it.
- The pre-v0.2.7 gap (~453 commits) is recorded as unexamined, not resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)