### PR TITLE
feat(tools,agent): add delegate tool for cross-agent task handoff

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -312,6 +312,15 @@ func registerSharedTools(
 				subagentTool := tools.NewSubagentTool(subagentManager)
 				subagentTool.SetSpawner(spawner)
 				agent.Tools.Register(subagentTool)
+
+				// Also register the delegate tool for cross-agent task handoff
+				delegateTool := tools.NewDelegateTool()
+				delegateTool.SetSpawner(spawner)
+				delegateTool.SetAllowlistChecker(func(targetAgentID string) bool {
+					return registry.CanSpawnSubagent(currentAgentID, targetAgentID)
+				})
+				delegateTool.SetSelfAgentID(currentAgentID)
+				agent.Tools.Register(delegateTool)
 			}
 		}
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -224,6 +224,71 @@ func TestToolRegistry_GetDefinitions(t *testing.T) {
 	}
 }
 
+// TestDelegateToolRegistration verifies that the delegate tool is registered
+// and wired up correctly when spawn tool is enabled.
+func TestDelegateToolRegistration(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "agent-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+		Tools: config.ToolsConfig{
+			Spawn: config.ToolConfig{Enabled: true},
+			Subagent: config.ToolConfig{Enabled: true},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &mockProvider{}
+	al := NewAgentLoop(cfg, msgBus, provider)
+
+	// Get the default agent to check if delegate tool is registered
+	agent := al.registry.GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("Expected default agent to be registered")
+	}
+
+	// Check that delegate tool is in the registered tools
+	info := al.GetStartupInfo()
+	toolsInfo := info["tools"].(map[string]any)
+	toolsList := toolsInfo["names"].([]string)
+
+	found := slices.Contains(toolsList, "delegate")
+	if !found {
+		t.Error("Expected delegate tool to be registered")
+	}
+
+	// Verify the delegate tool can be retrieved and is properly configured
+	delegateTool, ok := agent.Tools.Get("delegate")
+	if !ok {
+		t.Error("delegate tool not found in agent tools registry")
+	}
+
+	// Execute the delegate tool with a valid config to verify spawner is set
+	// (if spawner is not set, it returns "delegate tool not configured")
+	result := delegateTool.Execute(context.Background(), map[string]any{
+		"agent_id": "test_agent",
+		"task":     "test task",
+	})
+
+	// The tool should fail with something other than "not configured"
+	// (actual execution will fail because we don't have a real spawner,
+	// but the spawner is configured, so it won't return "not configured")
+	if result.IsError && strings.Contains(result.ForLLM, "not configured") {
+		t.Error("delegate tool appears to not be configured (spawner is nil)")
+	}
+}
+
 func TestProcessMessage_MediaToolHandledSkipsFollowUpLLMAndFinalText(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.Config{

--- a/pkg/tools/delegate.go
+++ b/pkg/tools/delegate.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/routing"
+)
+
+// DelegateTool delegates a task to a specific named agent and waits for
+// the result. Unlike spawn (async, fire-and-forget) or subagent (sync but
+// generic), delegate targets a named agent and runs the task using that
+// agent's own workspace, model, and tools.
+type DelegateTool struct {
+	spawner        SubTurnSpawner
+	allowlistCheck func(targetAgentID string) bool
+	selfAgentID    string
+}
+
+func NewDelegateTool() *DelegateTool {
+	return &DelegateTool{}
+}
+
+func (t *DelegateTool) SetSpawner(spawner SubTurnSpawner) {
+	t.spawner = spawner
+}
+
+func (t *DelegateTool) SetAllowlistChecker(check func(targetAgentID string) bool) {
+	t.allowlistCheck = check
+}
+
+func (t *DelegateTool) SetSelfAgentID(id string) {
+	t.selfAgentID = id
+}
+
+func (t *DelegateTool) Name() string {
+	return "delegate"
+}
+
+func (t *DelegateTool) Description() string {
+	return "Delegate a task to another agent and wait for the result. " +
+		"Use this when another agent is better suited to handle a specific task " +
+		"based on their capabilities. The target agent runs with its own workspace, " +
+		"model, and tools."
+}
+
+func (t *DelegateTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"agent_id": map[string]any{
+				"type":        "string",
+				"description": "The ID of the target agent to delegate the task to",
+			},
+			"task": map[string]any{
+				"type":        "string",
+				"description": "Clear description of the task to delegate",
+			},
+		},
+		"required": []string{"agent_id", "task"},
+	}
+}
+
+func (t *DelegateTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	rawAgentID, _ := args["agent_id"].(string)
+	if strings.TrimSpace(rawAgentID) == "" {
+		return ErrorResult("agent_id is required and must be a non-empty string")
+	}
+
+	task, _ := args["task"].(string)
+	if strings.TrimSpace(task) == "" {
+		return ErrorResult("task is required and must be a non-empty string")
+	}
+
+	agentID := routing.NormalizeAgentID(rawAgentID)
+
+	if t.selfAgentID != "" && agentID == routing.NormalizeAgentID(t.selfAgentID) {
+		return ErrorResult("cannot delegate to self")
+	}
+
+	if t.allowlistCheck != nil && !t.allowlistCheck(agentID) {
+		return ErrorResult(fmt.Sprintf("not allowed to delegate to agent %q", agentID))
+	}
+
+	if t.spawner == nil {
+		return ErrorResult("delegate tool not configured")
+	}
+
+	result, err := t.spawner.SpawnSubTurn(ctx, SubTurnConfig{
+		TargetAgentID: agentID,
+		SystemPrompt:  task,
+		Async:         false,
+	})
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("delegation to agent %q failed: %v", agentID, err)).WithError(err)
+	}
+	if result == nil {
+		return ErrorResult(fmt.Sprintf("delegation to agent %q returned no result", agentID))
+	}
+
+	result.ForLLM = fmt.Sprintf("[Response from agent %q]\n%s", agentID, result.ForLLM)
+
+	return result
+}

--- a/pkg/tools/delegate_test.go
+++ b/pkg/tools/delegate_test.go
@@ -1,0 +1,298 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// delegateMockSpawner records the config and returns a canned result.
+type delegateMockSpawner struct {
+	lastCfg      SubTurnConfig
+	result       *ToolResult
+	err          error
+	returnNilErr bool // When true, return (nil, nil) instead of default result
+}
+
+func (m *delegateMockSpawner) SpawnSubTurn(_ context.Context, cfg SubTurnConfig) (*ToolResult, error) {
+	m.lastCfg = cfg
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.returnNilErr {
+		return nil, nil
+	}
+	if m.result != nil {
+		return m.result, nil
+	}
+	return &ToolResult{
+		ForLLM:  "completed: " + cfg.SystemPrompt,
+		ForUser: "completed",
+	}, nil
+}
+
+func TestDelegateTool_Name(t *testing.T) {
+	tool := NewDelegateTool()
+	if tool.Name() != "delegate" {
+		t.Errorf("Name() = %q, want %q", tool.Name(), "delegate")
+	}
+}
+
+func TestDelegateTool_Parameters(t *testing.T) {
+	tool := NewDelegateTool()
+	params := tool.Parameters()
+
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties should be a map")
+	}
+	_, hasAgentID := props["agent_id"]
+	if !hasAgentID {
+		t.Error("agent_id parameter should exist")
+	}
+	_, hasTask := props["task"]
+	if !hasTask {
+		t.Error("task parameter should exist")
+	}
+
+	required, ok := params["required"].([]string)
+	if !ok {
+		t.Fatal("required should be a string array")
+	}
+	if len(required) != 2 {
+		t.Fatalf("required should have 2 entries, got %d", len(required))
+	}
+}
+
+func TestDelegateTool_Execute_Success(t *testing.T) {
+	spawner := &delegateMockSpawner{}
+	tool := NewDelegateTool()
+	tool.SetSpawner(spawner)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "researcher",
+		"task":     "summarize the logs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, `[Response from agent "researcher"]`) {
+		t.Errorf("result should contain attribution, got: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, "summarize the logs") {
+		t.Errorf("result should contain task output, got: %s", result.ForLLM)
+	}
+
+	// Verify spawner received correct config
+	if spawner.lastCfg.TargetAgentID != "researcher" {
+		t.Errorf("TargetAgentID = %q, want %q", spawner.lastCfg.TargetAgentID, "researcher")
+	}
+	if spawner.lastCfg.Async {
+		t.Error("delegate should be synchronous (Async=false)")
+	}
+	if spawner.lastCfg.SystemPrompt != "summarize the logs" {
+		t.Errorf("SystemPrompt = %q, want %q", spawner.lastCfg.SystemPrompt, "summarize the logs")
+	}
+}
+
+func TestDelegateTool_Execute_EmptyAgentID(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"missing", map[string]any{"task": "test"}},
+		{"empty string", map[string]any{"agent_id": "", "task": "test"}},
+		{"whitespace only", map[string]any{"agent_id": "  ", "task": "test"}},
+		{"wrong type", map[string]any{"agent_id": 123, "task": "test"}},
+	}
+
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tool.Execute(context.Background(), tt.args)
+			if !result.IsError {
+				t.Error("expected error for invalid agent_id")
+			}
+			if !strings.Contains(result.ForLLM, "agent_id is required") {
+				t.Errorf("error should mention agent_id, got: %s", result.ForLLM)
+			}
+		})
+	}
+}
+
+func TestDelegateTool_Execute_EmptyTask(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"missing", map[string]any{"agent_id": "a"}},
+		{"empty string", map[string]any{"agent_id": "a", "task": ""}},
+		{"whitespace only", map[string]any{"agent_id": "a", "task": "\t\n"}},
+	}
+
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tool.Execute(context.Background(), tt.args)
+			if !result.IsError {
+				t.Error("expected error for invalid task")
+			}
+			if !strings.Contains(result.ForLLM, "task is required") {
+				t.Errorf("error should mention task, got: %s", result.ForLLM)
+			}
+		})
+	}
+}
+
+func TestDelegateTool_Execute_PermissionDenied(t *testing.T) {
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+	tool.SetAllowlistChecker(func(id string) bool {
+		return id == "allowed"
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "denied",
+		"task":     "test",
+	})
+
+	if !result.IsError {
+		t.Error("expected permission denied error")
+	}
+	if !strings.Contains(result.ForLLM, "not allowed to delegate") {
+		t.Errorf("error should mention permission, got: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_PermissionAllowed(t *testing.T) {
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+	tool.SetAllowlistChecker(func(id string) bool {
+		return id == "allowed"
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "allowed",
+		"task":     "test",
+	})
+
+	if result.IsError {
+		t.Errorf("expected success, got error: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_NoAllowlistChecker(t *testing.T) {
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+	// No allowlist checker set, should allow all
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "any-agent",
+		"task":     "test",
+	})
+
+	if result.IsError {
+		t.Errorf("expected success when no checker, got error: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_SelfDelegation(t *testing.T) {
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+	tool.SetSelfAgentID("self")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "self",
+		"task":     "test",
+	})
+
+	if !result.IsError {
+		t.Error("expected error for self-delegation")
+	}
+	if !strings.Contains(result.ForLLM, "cannot delegate to self") {
+		t.Errorf("error should mention self-delegation, got: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_SelfDelegation_Normalized(t *testing.T) {
+	tool := NewDelegateTool()
+	tool.SetSpawner(&delegateMockSpawner{})
+	tool.SetSelfAgentID("alpha")
+
+	// Case-insensitive and whitespace variants should still be caught
+	variants := []string{"ALPHA", " Alpha ", "  alpha  "}
+	for _, v := range variants {
+		t.Run(v, func(t *testing.T) {
+			result := tool.Execute(context.Background(), map[string]any{
+				"agent_id": v,
+				"task":     "test",
+			})
+			if !result.IsError {
+				t.Errorf("agent_id=%q should be caught as self-delegation", v)
+			}
+		})
+	}
+}
+
+func TestDelegateTool_Execute_NilSpawner(t *testing.T) {
+	tool := NewDelegateTool()
+	// No spawner set
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "test",
+		"task":     "test",
+	})
+
+	if !result.IsError {
+		t.Error("expected error when spawner is nil")
+	}
+	if !strings.Contains(result.ForLLM, "not configured") {
+		t.Errorf("error should mention configuration, got: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_SpawnerError(t *testing.T) {
+	tool := NewDelegateTool()
+	spawner := &delegateMockSpawner{
+		err: fmt.Errorf("connection refused"),
+	}
+	tool.SetSpawner(spawner)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "test",
+		"task":     "test",
+	})
+
+	if !result.IsError {
+		t.Error("expected error from spawner")
+	}
+	if !strings.Contains(result.ForLLM, "connection refused") {
+		t.Errorf("error should contain spawner error, got: %s", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_NilResult(t *testing.T) {
+	tool := NewDelegateTool()
+	spawner := &delegateMockSpawner{
+		returnNilErr: true, // Return (nil, nil)
+	}
+	tool.SetSpawner(spawner)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "test",
+		"task":     "test",
+	})
+
+	if !result.IsError {
+		t.Error("expected error when spawner returns nil result")
+	}
+	if !strings.Contains(result.ForLLM, "returned no result") {
+		t.Errorf("error should mention no result, got: %s", result.ForLLM)
+	}
+}

--- a/pkg/tools/names.go
+++ b/pkg/tools/names.go
@@ -16,6 +16,7 @@ const (
 	NameFindSkills      = "find_skills"
 	NameInstallSkill    = "install_skill"
 	NameSpawn           = "spawn"
+	NameDelegate        = "delegate"
 	NameGetAssetsList   = "get_assets_list"
 	NameGetTotalValue   = "get_total_value"
 	NameListPortfolios  = "list_portfolios"

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -26,6 +26,7 @@ type SubTurnConfig struct {
 	Critical        bool          // continue running after parent finishes gracefully
 	Timeout         time.Duration // 0 = use default (5 minutes)
 	MaxContextRunes int           // 0 = auto, -1 = no limit, >0 = explicit limit
+	TargetAgentID   string        // for delegate tool: target a specific named agent
 }
 
 type SubagentTask struct {


### PR DESCRIPTION
## What this adds

The `delegate` tool — synchronous cross-agent task handoff — ported from upstream picoclaw
`484ef399`, `0ff78fa5`, `df486b99`, `6db17b82`, **and wired into the agent loop** so it is actually
reachable.

| Commit | What |
|---|---|
| `f0688ff1` | The tool: `pkg/tools/delegate.go`, `TargetAgentID` on `SubTurnConfig`, `NameDelegate` constant, 12 unit tests |
| `190da458` | Registration in `pkg/agent/loop.go` |
| `694e0171` | Test proving reachability through the agent |

## Why the wiring commit is the important one

This tool was implemented once before and **deliberately dropped from its PR** because nothing
registered it — `DelegateTool` returned "delegate tool not configured" at runtime. It would have
shipped as unreachable code that looked like a feature.

Registration now follows the existing sibling pattern in `pkg/agent/loop.go`, immediately after the
subagent tool:

```go
delegateTool := tools.NewDelegateTool()
delegateTool.SetSpawner(spawner)
delegateTool.SetAllowlistChecker(func(targetAgentID string) bool {
    return registry.CanSpawnSubagent(currentAgentID, targetAgentID)
})
delegateTool.SetSelfAgentID(currentAgentID)
agent.Tools.Register(delegateTool)
```

Permission reuses the agent registry's existing `CanSpawnSubagent` rules rather than inventing a
second authorization model. `SetSelfAgentID` is load-bearing — it is what makes the self-delegation
check work.

## Safety-relevant properties

- **Self-delegation is blocked, including case-variant bypasses.** `agent_id` is normalized before
  the self-check, so `ALPHA`, `Alpha`, and `alpha` are all caught against a self ID of `alpha`.
  Pinned by `TestDelegateTool_Execute_SelfDelegation_Normalized` (upstream `df486b99` + `6db17b82`).
- Delegation targets are gated by the agent registry's spawn allowlist.
- The tool is registered only where a spawner exists, so it cannot be invoked without one.

## How it was tested

`TestDelegateToolRegistration` asserts the tool is reachable through the agent's registry with a
spawner configured — not merely that the type works in isolation.

That distinction is the whole point, so I verified it by **mutation** rather than trusting a green
run: the 12 pre-existing unit tests all passed while the tool was dead code, so they prove nothing
about wiring.

```
# remove the registration
- agent.Tools.Register(delegateTool)
+ _ = delegateTool
→ TestDelegateToolRegistration FAILS
# restored
→ PASS
```

Also green: `go generate ./...`, `go build ./...`, full `go test ./...` (0 failures),
`golangci-lint v2.10.1` (0 issues).

## Known limitations

- The tool is registered inside the same branch that enables the spawn/subagent tools, so disabling
  those also removes `delegate`. That is intentional — it requires a spawner — but it does mean
  `delegate` is not independently toggleable.
- Delegation is synchronous (`Async: false`); the calling turn blocks until the target agent returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)