### PR TITLE
fix(tools): keep deny patterns active for custom allow rules

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -554,36 +554,37 @@ func localPathExists(cwd, token string) bool {
 	return err == nil && info != nil
 }
 
+// commandMatchesAllowPattern checks if a command matches either the standard
+// allow patterns or the custom allow patterns.
+func (t *ExecTool) commandMatchesAllowPattern(lower string) bool {
+	for _, pattern := range t.allowPatterns {
+		if pattern.MatchString(lower) {
+			return true
+		}
+	}
+	for _, pattern := range t.customAllowPatterns {
+		if pattern.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
 
-	// Custom allow patterns exempt a command from deny checks.
-	explicitlyAllowed := false
-	for _, pattern := range t.customAllowPatterns {
+	// Deny patterns always apply, even when a command matches a custom allow rule.
+	// Custom allow rules can permit a command, but must not disable secret-safety
+	// deny rules such as jq env access checks.
+	for _, pattern := range t.denyPatterns {
 		if pattern.MatchString(lower) {
-			explicitlyAllowed = true
-			break
+			return "Command blocked by safety guard (dangerous pattern detected)"
 		}
 	}
 
-	if !explicitlyAllowed {
-		for _, pattern := range t.denyPatterns {
-			if pattern.MatchString(lower) {
-				return "Command blocked by safety guard (dangerous pattern detected)"
-			}
-		}
-	}
-
-	if len(t.allowPatterns) > 0 {
-		allowed := false
-		for _, pattern := range t.allowPatterns {
-			if pattern.MatchString(lower) {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
+	if len(t.allowPatterns) > 0 || len(t.customAllowPatterns) > 0 {
+		if !t.commandMatchesAllowPattern(lower) {
 			return "Command blocked by safety guard (not in allowlist)"
 		}
 	}

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -583,7 +583,7 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 		}
 	}
 
-	if len(t.allowPatterns) > 0 || len(t.customAllowPatterns) > 0 {
+	if len(t.allowPatterns) > 0 {
 		if !t.commandMatchesAllowPattern(lower) {
 			return "Command blocked by safety guard (not in allowlist)"
 		}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -1185,3 +1185,19 @@ func TestShellTool_SchemelessURLDetection(t *testing.T) {
 		}
 	}
 }
+
+func TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Exec.EnableDenyPatterns = true
+	cfg.Tools.Exec.CustomAllowPatterns = []string{`^jq\b`}
+
+	tool, err := NewExecToolWithConfig(t.TempDir(), false, cfg)
+	if err != nil {
+		t.Fatalf("NewExecToolWithConfig() error: %v", err)
+	}
+
+	got := tool.guardCommand("ls", t.TempDir())
+	if got != "" {
+		t.Fatalf("custom allow patterns should not become a strict allowlist, got: %q", got)
+	}
+}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -831,7 +831,7 @@ func TestGuardCommand_AllowlistPermits(t *testing.T) {
 	}
 }
 
-func TestGuardCommand_CustomAllowExemptsDeny(t *testing.T) {
+func TestGuardCommand_CustomAllowWithoutDenyMatch(t *testing.T) {
 	tmp := t.TempDir()
 	cfg := config.DefaultConfig()
 	cfg.Tools.Exec.EnableDenyPatterns = true
@@ -840,10 +840,42 @@ func TestGuardCommand_CustomAllowExemptsDeny(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecToolWithConfig: %v", err)
 	}
-	// "rm" is custom-allowed, so deny pattern should not fire
+	// "rm somefile" is custom-allowed and matches no deny pattern, so it should pass.
 	msg := tool.guardCommand("rm somefile", tmp)
 	if msg != "" {
-		t.Errorf("custom-allowed command should not be blocked, got %q", msg)
+		t.Errorf("custom-allowed command matching no deny pattern should not be blocked, got %q", msg)
+	}
+}
+
+func TestShellTool_CustomAllowDoesNotBypassDenyPatterns(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Exec.EnableDenyPatterns = true
+	cfg.Tools.Exec.CustomAllowPatterns = []string{`^rm\b`}
+
+	tool, err := NewExecToolWithConfig(t.TempDir(), false, cfg)
+	if err != nil {
+		t.Fatalf("NewExecToolWithConfig() error: %v", err)
+	}
+
+	got := tool.guardCommand(`rm -rf somedir`, t.TempDir())
+	if !strings.Contains(got, "dangerous pattern detected") {
+		t.Fatalf("custom allow should not bypass deny patterns, got: %q", got)
+	}
+}
+
+func TestShellTool_CustomAllowStillPermitsSafeMatch(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Exec.EnableDenyPatterns = true
+	cfg.Tools.Exec.CustomAllowPatterns = []string{`^jq\b`}
+
+	tool, err := NewExecToolWithConfig(t.TempDir(), false, cfg)
+	if err != nil {
+		t.Fatalf("NewExecToolWithConfig() error: %v", err)
+	}
+
+	got := tool.guardCommand(`jq -n '"ok"'`, t.TempDir())
+	if got != "" {
+		t.Fatalf("safe custom-allowed command should pass guard, got: %q", got)
 	}
 }
 

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -553,8 +553,9 @@ func TestShellTool_TimeoutWithPartialOutput(t *testing.T) {
 	t.Logf("Timeout result: %s", result.ForLLM)
 }
 
-// TestShellTool_CustomAllowPatterns verifies that custom allow patterns exempt
-// commands from deny pattern checks.
+// TestShellTool_CustomAllowPatterns verifies that custom allow patterns can
+// permit a command that would otherwise fail the allowlist check, while deny
+// patterns continue to apply unconditionally.
 func TestShellTool_CustomAllowPatterns(t *testing.T) {
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
@@ -575,7 +576,7 @@ func TestShellTool_CustomAllowPatterns(t *testing.T) {
 		"command": "git push origin main",
 	})
 	if result.IsError && strings.Contains(result.ForLLM, "blocked") {
-		t.Errorf("custom allow pattern should exempt 'git push origin main', got: %s", result.ForLLM)
+		t.Errorf("custom allow pattern should permit 'git push origin main' when allow patterns are not set, got: %s", result.ForLLM)
 	}
 
 	// "git push upstream main" should still be blocked (does not match allow pattern).


### PR DESCRIPTION
## What this fixes

A **custom allow pattern could disable every deny pattern** for a matching command.

`pkg/tools/shell.go` previously read:
```go
// Custom allow patterns exempt a command from deny checks.
explicitlyAllowed := false
for _, pattern := range t.customAllowPatterns {
    if pattern.MatchString(lower) { explicitlyAllowed = true; break }
}

if !explicitlyAllowed {
    for _, pattern := range t.denyPatterns { ... }   // ← skipped entirely
}
```

So a single `custom_allow_patterns` entry matching a command turned off **all** deny rules for it —
including the PowerShell encoding-bypass guards, `rm -rf`, `sudo`, `| sh`, and the path-traversal
patterns this repo hardened in #50. The protections shipped three merges ago were bypassable by
configuration.

Hand-ported from upstream `9721c36e` and its follow-up `ff247b63`.

| Commit | Upstream | What |
|---|---|---|
| `694a7c97` | `9721c36e` | Deny patterns always apply; extract `commandMatchesAllowPattern` |
| `27f402f3` | `ff247b63` | Preserve *additive* custom-allow behaviour |
| `8005525c` | — | Correct comments that described the removed vulnerability |

## Safety-relevant properties

The corrected order in `guardCommand`:
```go
// Deny patterns always apply, even when a command matches a custom allow rule.
for _, pattern := range t.denyPatterns {
    if pattern.MatchString(lower) {
        return "Command blocked by safety guard (dangerous pattern detected)"
    }
}

if len(t.allowPatterns) > 0 {
    if !t.commandMatchesAllowPattern(lower) {
        return "Command blocked by safety guard (not in allowlist)"
    }
}
```

A custom allow rule may now **satisfy the allowlist requirement**, but can never **disable a deny
rule**. The follow-up commit matters: without it, the first change would have turned custom allow
patterns into a strict allowlist, which is a different behaviour regression — `ff247b63` restores the
additive semantics. Both, or neither.

## How it was tested

A test asserting the vulnerability as intended behaviour — `TestGuardCommand_CustomAllowExemptsDeny`
— was **removed**, not preserved, and replaced with four that pin the correct semantics:
`TestShellTool_CustomAllowDoesNotBypassDenyPatterns`, `TestShellTool_CustomAllowStillPermitsSafeMatch`,
`TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist`, `TestGuardCommand_CustomAllowWithoutDenyMatch`.

Verified by **mutation**, not just a green run — I restored the short-circuit:
```
+ if explicitlyAllowed { goto afterDeny }
→ TestShellTool_CustomAllowDoesNotBypassDenyPatterns FAILS
# restored → passes
```

The earlier hardening is confirmed intact: `TestPowerShellEncodingBypass`,
`TestPathTraversalVariants`, and `TestShellTool_SchemelessURLDetection` all still pass.

Also green: `go generate ./...`, `go build ./...`, full `go test ./...` (**0 failures**),
`golangci-lint v2.10.1` (0 issues).

## Known limitations

- Upstream `9721c36e` also touches `pkg/providers/openai_compat/provider.go` (+1 line). That hunk is
  unrelated drive-by churn and was not ported.
- This restores the intended layering, but the exec guard remains a **regex layer with no OS-level
  process isolation behind it** — see `SECURITY.md`. A deny-pattern gap is still a full bypass; this
  change removes a way to switch the layer off, not the layer's inherent limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)