### PR TITLE
fix(providers): recover tool call name from Function on reloaded history

### DIFF
--- a/pkg/providers/anthropic/provider.go
+++ b/pkg/providers/anthropic/provider.go
@@ -193,20 +193,12 @@ func buildParams(
 					blocks = append(blocks, anthropic.NewTextBlock(msg.Content))
 				}
 				for _, tc := range msg.ToolCalls {
-					// Skip tool calls with empty names to avoid API errors
-					if tc.Name == "" {
+					// Skip tool calls with empty names and no Function fallback to avoid API errors
+					name, args, ok := resolveToolCall(tc)
+					if !ok {
 						continue
 					}
-					args := tc.Arguments
-					if args == nil && tc.Function != nil && tc.Function.Arguments != "" {
-						if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
-							args = map[string]any{}
-						}
-					}
-					if args == nil {
-						args = map[string]any{}
-					}
-					blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, args, tc.Name))
+					blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, args, name))
 				}
 				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))
 			} else {
@@ -346,6 +338,31 @@ func translateTools(tools []ToolDefinition) []anthropic.ToolUnionParam {
 		result = append(result, anthropic.ToolUnionParam{OfTool: &tool})
 	}
 	return result
+}
+
+// resolveToolCall resolves a ToolCall's name and arguments, using Function
+// as a fallback for fields that don't serialize (json:"-").
+// Returns (name, args, ok). ok is false when both Name and Function.Name are empty.
+func resolveToolCall(tc ToolCall) (string, map[string]any, bool) {
+	name := tc.Name
+	if name == "" && tc.Function != nil {
+		name = tc.Function.Name
+	}
+	if name == "" {
+		return "", nil, false
+	}
+
+	args := tc.Arguments
+	if args == nil && tc.Function != nil && tc.Function.Arguments != "" {
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+			args = map[string]any{}
+		}
+	}
+	if args == nil {
+		args = map[string]any{}
+	}
+
+	return name, args, true
 }
 
 func parseResponse(resp *anthropic.Message) *LLMResponse {

--- a/pkg/providers/anthropic/provider_test.go
+++ b/pkg/providers/anthropic/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -318,6 +319,149 @@ func TestProvider_ChatStreamingRoundTrip(t *testing.T) {
 	}
 	if resp.Usage.CompletionTokens != 5 {
 		t.Errorf("CompletionTokens = %d, want 5", resp.Usage.CompletionTokens)
+	}
+}
+
+func TestBuildParams_ToolCallMessage_FreshNameDoesNotRegress(t *testing.T) {
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_1",
+					Name:      "get_weather",
+					Arguments: map[string]any{"city": "SF"},
+				},
+			},
+		},
+	}
+	params, err := buildParams(messages, nil, "claude-sonnet-4.6", map[string]any{})
+	if err != nil {
+		t.Fatalf("buildParams() error: %v", err)
+	}
+
+	if len(params.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(params.Messages))
+	}
+
+	// Marshal to JSON to inspect the content blocks reliably
+	msgJSON, err := json.Marshal(params.Messages[1])
+	if err != nil {
+		t.Fatalf("failed to marshal message: %v", err)
+	}
+
+	msgStr := string(msgJSON)
+	if !strings.Contains(msgStr, "get_weather") {
+		t.Errorf("tool_use block with name 'get_weather' not found in message: %s", msgStr)
+	}
+	if !strings.Contains(msgStr, "tool_use") {
+		t.Errorf("tool_use type not found in message: %s", msgStr)
+	}
+	if !strings.Contains(msgStr, "call_1") {
+		t.Errorf("tool call ID not found in message: %s", msgStr)
+	}
+}
+
+func TestBuildParams_ToolCallMessage_RoundTripRecovery(t *testing.T) {
+	// This test simulates a persisted tool call where Name and Arguments
+	// were not serialized (json:"-"), but Function contains the data.
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_1",
+					Name:      "",
+					Arguments: nil,
+					Function: &FunctionCall{
+						Name:      "get_weather",
+						Arguments: `{"city":"SF"}`,
+					},
+				},
+			},
+		},
+	}
+	params, err := buildParams(messages, nil, "claude-sonnet-4.6", map[string]any{})
+	if err != nil {
+		t.Fatalf("buildParams() error: %v", err)
+	}
+
+	if len(params.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(params.Messages))
+	}
+
+	// Verify the tool_use block is included despite empty Name and Arguments
+	msgJSON, err := json.Marshal(params.Messages[1])
+	if err != nil {
+		t.Fatalf("failed to marshal message: %v", err)
+	}
+
+	msgStr := string(msgJSON)
+	if !strings.Contains(msgStr, "get_weather") {
+		t.Errorf("tool_use block with name 'get_weather' not found in round-tripped message: %s", msgStr)
+	}
+	if !strings.Contains(msgStr, "tool_use") {
+		t.Errorf("tool_use type not found in round-tripped message: %s", msgStr)
+	}
+	if !strings.Contains(msgStr, "SF") {
+		t.Errorf("arguments with 'SF' not found in round-tripped message: %s", msgStr)
+	}
+}
+
+func TestBuildParams_ToolCallMessage_BothNamesEmptySkipped(t *testing.T) {
+	// Both Name and Function.Name empty => should skip the tool call
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "Using a tool",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_empty",
+					Name:      "",
+					Arguments: map[string]any{"some": "arg"},
+					Function: &FunctionCall{
+						Name:      "",
+						Arguments: `{}`,
+					},
+				},
+				{
+					ID:        "call_valid",
+					Name:      "valid_tool",
+					Arguments: map[string]any{"arg": "value"},
+				},
+			},
+		},
+	}
+	params, err := buildParams(messages, nil, "claude-sonnet-4.6", map[string]any{})
+	if err != nil {
+		t.Fatalf("buildParams() error: %v", err)
+	}
+
+	if len(params.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(params.Messages))
+	}
+
+	// Verify only the valid tool call is included
+	msgJSON, err := json.Marshal(params.Messages[1])
+	if err != nil {
+		t.Fatalf("failed to marshal message: %v", err)
+	}
+
+	msgStr := string(msgJSON)
+	if strings.Contains(msgStr, "call_empty") {
+		t.Errorf("empty-named tool call should have been skipped: %s", msgStr)
+	}
+	if !strings.Contains(msgStr, "valid_tool") {
+		t.Errorf("valid_tool not found in message: %s", msgStr)
+	}
+	// Message content should be included
+	if !strings.Contains(msgStr, "Using a tool") {
+		t.Errorf("text content not found in message: %s", msgStr)
 	}
 }
 

--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -227,20 +227,16 @@ func buildRequestBody(
 
 			// Add tool_use blocks
 			for _, tc := range msg.ToolCalls {
-				if strings.TrimSpace(tc.Name) == "" {
+				// Skip tool calls with empty names and no Function fallback to avoid API errors
+				name, input, ok := resolveToolCall(tc)
+				if !ok {
 					continue
-				}
-
-				// Handle nil Arguments (GLM-4 may return null input)
-				input := tc.Arguments
-				if input == nil {
-					input = map[string]any{}
 				}
 
 				toolUse := map[string]any{
 					"type":  "tool_use",
 					"id":    tc.ID,
-					"name":  tc.Name,
+					"name":  name,
 					"input": input,
 				}
 				content = append(content, toolUse)
@@ -409,6 +405,31 @@ func asFloat(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// resolveToolCall resolves a ToolCall's name and arguments, using Function
+// as a fallback for fields that don't serialize (json:"-").
+// Returns (name, args, ok). ok is false when both Name and Function.Name are empty.
+func resolveToolCall(tc ToolCall) (string, map[string]any, bool) {
+	name := tc.Name
+	if name == "" && tc.Function != nil {
+		name = tc.Function.Name
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", nil, false
+	}
+
+	args := tc.Arguments
+	if args == nil && tc.Function != nil && tc.Function.Arguments != "" {
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+			args = map[string]any{}
+		}
+	}
+	if args == nil {
+		args = map[string]any{}
+	}
+
+	return name, args, true
 }
 
 // Anthropic API response structures

--- a/pkg/providers/anthropic_messages/provider_test.go
+++ b/pkg/providers/anthropic_messages/provider_test.go
@@ -723,6 +723,198 @@ func TestParseResponseBodyEdgeCases(t *testing.T) {
 	}
 }
 
+func TestBuildRequestBody_ToolCallMessage_FreshNameDoesNotRegress(t *testing.T) {
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_1",
+					Name:      "get_weather",
+					Arguments: map[string]any{"city": "SF"},
+				},
+			},
+		},
+	}
+	body, err := buildRequestBody(messages, nil, "test-model", map[string]any{"max_tokens": 8192})
+	if err != nil {
+		t.Fatalf("buildRequestBody() error: %v", err)
+	}
+
+	msgList, ok := body["messages"].([]any)
+	if !ok || len(msgList) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgList))
+	}
+
+	assistantMsg, ok := msgList[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected assistant message to be map, got %T", msgList[1])
+	}
+
+	content, ok := assistantMsg["content"].([]any)
+	if !ok {
+		t.Fatalf("expected content to be []any, got %T", assistantMsg["content"])
+	}
+
+	// Should have tool_use block with fresh Name
+	found := false
+	for _, block := range content {
+		if blockMap, ok := block.(map[string]any); ok {
+			if blockMap["type"] == "tool_use" && blockMap["name"] == "get_weather" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("tool_use block with name 'get_weather' not found in content: %v", content)
+	}
+}
+
+func TestBuildRequestBody_ToolCallMessage_RoundTripRecovery(t *testing.T) {
+	// This test simulates a persisted tool call where Name and Arguments
+	// were not serialized (json:"-"), but Function contains the data.
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_1",
+					Name:      "",
+					Arguments: nil,
+					Function: &FunctionCall{
+						Name:      "get_weather",
+						Arguments: `{"city":"SF"}`,
+					},
+				},
+			},
+		},
+	}
+	body, err := buildRequestBody(messages, nil, "test-model", map[string]any{"max_tokens": 8192})
+	if err != nil {
+		t.Fatalf("buildRequestBody() error: %v", err)
+	}
+
+	msgList, ok := body["messages"].([]any)
+	if !ok || len(msgList) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgList))
+	}
+
+	assistantMsg, ok := msgList[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected assistant message to be map, got %T", msgList[1])
+	}
+
+	content, ok := assistantMsg["content"].([]any)
+	if !ok {
+		t.Fatalf("expected content to be []any, got %T", assistantMsg["content"])
+	}
+
+	// Should have tool_use block recovered from Function despite empty Name and Arguments
+	found := false
+	for _, block := range content {
+		if blockMap, ok := block.(map[string]any); ok {
+			if blockMap["type"] == "tool_use" && blockMap["name"] == "get_weather" {
+				// Verify input is also recovered
+				if input, ok := blockMap["input"].(map[string]any); ok {
+					if input["city"] == "SF" {
+						found = true
+						break
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("tool_use block with name 'get_weather' and city='SF' not found in round-tripped content: %v", content)
+	}
+}
+
+func TestBuildRequestBody_ToolCallMessage_BothNamesEmptySkipped(t *testing.T) {
+	// Both Name and Function.Name empty => should skip the tool call
+	messages := []Message{
+		{Role: "user", Content: "Call the tool"},
+		{
+			Role:    "assistant",
+			Content: "Using a tool",
+			ToolCalls: []ToolCall{
+				{
+					ID:        "call_empty",
+					Name:      "",
+					Arguments: map[string]any{"some": "arg"},
+					Function: &FunctionCall{
+						Name:      "",
+						Arguments: `{}`,
+					},
+				},
+				{
+					ID:        "call_valid",
+					Name:      "valid_tool",
+					Arguments: map[string]any{"arg": "value"},
+				},
+			},
+		},
+	}
+	body, err := buildRequestBody(messages, nil, "test-model", map[string]any{"max_tokens": 8192})
+	if err != nil {
+		t.Fatalf("buildRequestBody() error: %v", err)
+	}
+
+	msgList, ok := body["messages"].([]any)
+	if !ok || len(msgList) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgList))
+	}
+
+	assistantMsg, ok := msgList[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected assistant message to be map, got %T", msgList[1])
+	}
+
+	content, ok := assistantMsg["content"].([]any)
+	if !ok {
+		t.Fatalf("expected content to be []any, got %T", assistantMsg["content"])
+	}
+
+	// First block should be text, second should be valid_tool (not call_empty)
+	if len(content) < 2 {
+		t.Fatalf("expected at least 2 content blocks, got %d", len(content))
+	}
+
+	textFound := false
+	validToolFound := false
+	emptyToolFound := false
+
+	for _, block := range content {
+		if blockMap, ok := block.(map[string]any); ok {
+			if blockMap["type"] == "text" && blockMap["text"] == "Using a tool" {
+				textFound = true
+			}
+			if blockMap["type"] == "tool_use" {
+				if blockMap["name"] == "valid_tool" {
+					validToolFound = true
+				}
+				if blockMap["id"] == "call_empty" {
+					emptyToolFound = true
+				}
+			}
+		}
+	}
+
+	if !textFound {
+		t.Error("text content 'Using a tool' not found")
+	}
+	if !validToolFound {
+		t.Error("valid_tool not found")
+	}
+	if emptyToolFound {
+		t.Error("call_empty should have been skipped")
+	}
+}
+
 // TestProviderChatErrors tests error handling in Chat.
 // Note: apiBase check removed as it's dead code - normalizeBaseURL() always provides a default.
 func TestProviderChatErrors(t *testing.T) {


### PR DESCRIPTION
## What this fixes

Assistant tool calls were **silently dropped** from Anthropic requests after a session round-trip,
producing a hard 400 that killed every subsequent turn in that session.

`ToolCall` marks two fields as non-serializing (`pkg/providers/protocoltypes/types.go`):
```go
ID        string         `json:"id"`
Function  *FunctionCall  `json:"function,omitempty"`   // ← survives persistence
Name      string         `json:"-"`                    // ← does NOT
Arguments map[string]any `json:"-"`                    // ← does NOT
```

So on reload, only `Function` carries the data — but **both** Anthropic providers read `tc.Name` and
skipped the call when it was empty:

| File | Before |
|---|---|
| `pkg/providers/anthropic/provider.go:197` | `if tc.Name == "" { continue }` — had an `Arguments` fallback, but **no `Name` fallback**, and the name check short-circuits first |
| `pkg/providers/anthropic_messages/provider.go:230` | `if strings.TrimSpace(tc.Name) == "" { continue }` — no fallback at all |

**Impact:** on any turn that resends persisted history, assistant `tool_use` blocks vanish while their
`tool_result` blocks remain. The Anthropic API requires them paired, so the request is rejected. The
failure is silent, permanent for that session, and only recoverable by clearing history — and it
affects the **primary SDK-based Anthropic path**, not just the hand-rolled one.

Ported from upstream `994c0aea`, adapted to our layout.

## Safety-relevant properties

- **The `json:"-"` tags are deliberately unchanged.** Making `Name`/`Arguments` serialize would fix the
  symptom but alter the persisted session format — a compatibility risk far larger than the bug. The
  fallback is the correct remedy. Verified: zero diff under `pkg/providers/protocoltypes/`.
- The original guard's purpose is preserved: a call with **both** `Name` and `Function` empty is still
  skipped, so genuinely malformed calls cannot reach the API.
- `anthropic_messages` also gains the `Arguments` fallback it never had, so a round-tripped call
  recovers both its name and its input.
- Per-package helpers rather than a shared one — the two providers have different emptiness semantics
  (`== ""` vs `TrimSpace() == ""`), and collapsing them would have changed behaviour in one of them.

The correct reference pattern already existed in this repo — `antigravity_provider.go:366` and
`codex_provider.go:354` both do this properly. Only the two Anthropic providers were missing it.

## How it was tested

Three tests per provider: fresh-name regression, round-trip recovery, and both-empty-still-skipped.
They assert on the **marshaled request JSON** — confirming the `tool_use` block is actually present
with the right name and arguments — rather than just counting messages.

Verified by **mutation**, independently of the authoring agent:
```
# remove the Name fallback in both providers
→ TestBuildParams_ToolCallMessage_RoundTripRecovery            FAILS
→ TestBuildRequestBody_ToolCallMessage_RoundTripRecovery       FAILS
# restored → both pass
```

Also green: `go build ./...`, `go test ./pkg/providers/...` (0 failures), `golangci-lint v2.10.1`
(0 issues).

## Known limitations

- Only the two Anthropic providers are changed. `antigravity` and `codex` were checked and already
  correct; other providers do not read `tc.Name` on this path.
- This fixes reconstruction on the request side. It does not change how sessions are persisted, so
  histories written before this change still carry only `Function` — which is exactly what the
  fallback now reads, so they recover without migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)