### PR TITLE
chore(docker): align builder Go version with go.mod

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-FROM golang:1.26-alpine AS builder
+# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# This ensures the builder uses exactly what CI tests.
+FROM golang:1.25.13-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,7 +1,9 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-FROM golang:1.26.3-alpine AS builder
+# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# This ensures the builder uses exactly what CI tests.
+FROM golang:1.25.13-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/docker/Dockerfile.heavy
+++ b/docker/Dockerfile.heavy
@@ -1,7 +1,9 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-FROM golang:1.26.3-alpine AS builder
+# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# This ensures the builder uses exactly what CI tests.
+FROM golang:1.25.13-alpine AS builder
 
 RUN apk add --no-cache git make
 


### PR DESCRIPTION
## What this changes

All three Dockerfiles now build with `golang:1.25.13-alpine`, matching the `go` directive in `go.mod`.

| File | Before | After |
|---|---|---|
| `docker/Dockerfile` | `golang:1.26-alpine` | `golang:1.25.13-alpine` |
| `docker/Dockerfile.full` | `golang:1.26.3-alpine` | `golang:1.25.13-alpine` |
| `docker/Dockerfile.heavy` | `golang:1.26.3-alpine` | `golang:1.25.13-alpine` |

## Why

This was **drift, not a decision**. The three files did not even agree with each other
(`1.26-alpine` vs `1.26.3-alpine`), and none matched `go.mod`.

It was never broken — a newer toolchain compiles an older `go` directive fine — but it meant
**container images were built with a Go version CI never exercises**. `.github/workflows/pr.yml` uses
`actions/setup-go` with `go-version-file: go.mod`, so lint, tests, and `govulncheck` all run on
1.25.13 while the shipped image was built on 1.26.x.

Pinning to `go.mod` makes the container use exactly what was tested. A comment in each file records
the intent, so the next person bumping Go updates `go.mod` first and syncs the Dockerfiles in the same
change rather than letting them drift apart again.

The alternative — deliberately running a newer builder — is defensible, but it should then be
consistent across the three files and explicitly justified. Neither was true here.

## How it was verified

- **The pinned tag exists.** Confirmed against the Docker Hub registry API:
  `library/golang:1.25.13-alpine`, last pushed 2026-08-16. This was checked independently rather than
  assumed — pinning to an unpullable tag would break every container build.
- `go build ./...` and `make build` both pass on 1.25.13.
- No CVE regression: `govulncheck` is clean on `main` at 1.25.13, so this does not pin below a version
  that fixes something.

## Known limitations

- **The image builds were not actually run** — no Docker daemon was available in this environment. Tag
  existence, Dockerfile syntax, and a local Go build were verified instead. CI or the first real image
  build is the remaining confirmation.
- The Go version is now written in two places (`go.mod` and the Dockerfiles). That is the cost of
  pinning; the inline comments are there to make the coupling obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)