### PR TITLE
chore(deps): stop Dependabot bumping the Docker golang image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,11 @@ updates:
       docker-images:
         patterns:
           - "*"
+    ignore:
+      # The builder image is pinned to the exact toolchain in go.mod (see PR #64),
+      # so an automatic bump silently un-aligns the two. Update both together by
+      # hand when the Go version moves.
+      - dependency-name: "golang"
 
   - package-ecosystem: "docker-compose"
     directory: "/docker"


### PR DESCRIPTION
## What this adds

An `ignore` rule for the `golang` dependency in the `docker` ecosystem, so Dependabot stops
proposing builder-image bumps for `/docker`.

## Why

PR #64 pinned the builder image in all three Dockerfiles to the exact toolchain in `go.mod`
(`golang:1.25.13-alpine`). Dependabot has no knowledge of that coupling, so its weekly
`docker-images` group keeps proposing a newer tag — **#67 asked for `1.27-alpine` days after #64
landed**, which would silently undo the alignment #64 exists to create.

Closing these PRs does not work: #45-#48 were closed during the upstream sync and came straight back
as #66/#67 on the next run. The rule is the fix; closing is not.

## Safety-relevant properties

- **Narrowly scoped** — only `dependency-name: "golang"` in the `docker` ecosystem. Every other image
  in `/docker`, and all four other ecosystems (gomod, npm, github-actions, docker-compose), continue
  to receive updates unchanged.
- **Not a security silencer.** Go toolchain CVEs reach us through `go.mod`, which the `gomod`
  ecosystem still watches weekly — that is how the six stdlib CVEs in PR #49 were caught. This rule
  only stops the *image tag* from drifting away from `go.mod`; it does not stop us from learning the
  Go version needs to move.
- **Trade-off, stated plainly:** bumping Go now requires editing `go.mod` and the three Dockerfiles
  together, by hand. That coupling is the point — the comment in the config says so, so the next
  person does not have to reconstruct the reasoning from git history.

## How it was tested

Parsed with `yaml.safe_load`; the docker entry resolves to
`ignore: [{'dependency-name': 'golang'}]`. No CI check covers `dependabot.yml`, so the real
verification is behavioural: **#67 should not reappear after the next Monday 09:45 Asia/Bangkok run.**

## Known limitations

- Does not close #67 itself — that PR still needs closing by hand, and this rule prevents the
  recurrence rather than the existing instance.
- If Dependabot's group config takes precedence over `ignore` in some edge case, the rule would be
  inert; the Monday run is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN