### PR TITLE
fix(web): stop returning the Pico WebSocket token to clients

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,6 +111,10 @@ State-changing launcher endpoints (currently `/api/pico/setup` only) are protect
   10. **Updates** (`POST /api/update/apply`)
   
   Read-only endpoints (GET requests) are not protected. Certain operations deliberately excluded (see below).
+- **Pico WebSocket token is never sent to the browser**: The Pico channel authenticates its WebSocket handshake with a `token.<value>` subprotocol. The launcher proxies `/pico/ws` and attaches that token server-side from config, so no API response carries it and no browser holds it. `GET /api/pico/info` returns only `ws_url` and `enabled`; `POST /api/pico/token` rotates the token and returns the same token-free payload. The proxy also discards any subprotocol the caller supplied, so a client cannot present a token of its own choosing to the gateway, and strips the gateway's echoed subprotocol from the handshake response.
+
+  **Limitation:** this confines the token to the server; it is not itself an authentication boundary. `/pico/ws` is gated by the launcher session/password middleware (`apiRequiresAuth` in `web/backend/middleware/auth.go`), and that gate — not token confinement — is what stops an unauthenticated client from reaching the gateway. Anyone who can read `config.json` still has the token.
+
 - **Non-browser clients can spoof CSRF headers**: A client that is not a web browser (e.g., a custom HTTP client or an attacker's tool) can arbitrarily set `Sec-Fetch-Site`, `Origin`, and `Referer` headers. CSRF protection assumes these headers are set by the browser and cannot be forged; this assumption breaks for non-browser clients. CSRF protection is part of the application-level defense but is **not a substitute for IP allowlist and password authentication**, which govern non-browser access.
 
 ### CSRF Protection Coverage & Special Cases

--- a/web/backend/api/pico.go
+++ b/web/backend/api/pico.go
@@ -13,9 +13,18 @@ import (
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
 )
 
+const (
+	// picoProtocolHeader carries the WebSocket subprotocol used by the Pico
+	// channel to authenticate a handshake.
+	picoProtocolHeader = "Sec-WebSocket-Protocol"
+	// picoTokenSubprotocol is the prefix the Pico channel strips to recover the
+	// token (see matchedSubprotocol in pkg/channels/pico/pico.go).
+	picoTokenSubprotocol = "token."
+)
+
 // registerPicoRoutes binds Pico Channel management endpoints to the ServeMux.
 func (h *Handler) registerPicoRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/pico/token", h.handleGetPicoToken)
+	mux.HandleFunc("GET /api/pico/info", h.handleGetPicoInfo)
 	mux.HandleFunc("POST /api/pico/token", h.handleRegenPicoToken)
 	mux.HandleFunc("POST /api/pico/setup", h.handlePicoSetup)
 
@@ -23,6 +32,7 @@ func (h *Handler) registerPicoRoutes(mux *http.ServeMux) {
 	// This allows the frontend to connect via the same port as the web UI,
 	// avoiding the need to expose extra ports for WebSocket communication.
 	// SessionAuth middleware gates this path with launcher token (see middleware/auth.go apiRequiresAuth).
+	// The proxy injects the Pico token server-side, so the browser never holds it.
 	wsProxy := h.createWsProxy()
 	mux.HandleFunc("GET /pico/ws", h.handleWebSocketProxy(wsProxy))
 }
@@ -37,10 +47,45 @@ func (h *Handler) createWsProxy() *httputil.ReverseProxy {
 	}
 	gatewayURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", gatewayPort))
 	wsProxy := httputil.NewSingleHostReverseProxy(gatewayURL)
+
+	baseDirector := wsProxy.Director
+	wsProxy.Director = func(r *http.Request) {
+		baseDirector(r)
+		// The Pico channel authenticates the WebSocket handshake with a
+		// "token.<value>" subprotocol. Read that token from config here and
+		// attach it on the way out, so the browser never receives it. Any
+		// subprotocol the client supplied is discarded rather than forwarded:
+		// a caller must not be able to present its own token to the gateway.
+		r.Header.Del(picoProtocolHeader)
+		if token := h.picoToken(); token != "" {
+			r.Header.Set(picoProtocolHeader, picoTokenSubprotocol+token)
+		}
+	}
+	wsProxy.ModifyResponse = func(resp *http.Response) error {
+		// The gateway echoes the accepted subprotocol, which is the token
+		// itself — strip it so the handshake response cannot leak it either.
+		// Removed rather than rewritten: RFC 6455 requires the server's chosen
+		// subprotocol to be one the client offered, and the client now offers
+		// none, so any value here would fail the browser's handshake check.
+		resp.Header.Del(picoProtocolHeader)
+		return nil
+	}
 	wsProxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		http.Error(w, "Gateway unavailable: "+err.Error(), http.StatusBadGateway)
 	}
 	return wsProxy
+}
+
+// picoToken reads the current Pico channel token from config, or "" when it is
+// unset or the config cannot be read. Read per request rather than captured at
+// startup so a token regenerated via POST /api/pico/token takes effect without
+// a launcher restart.
+func (h *Handler) picoToken() string {
+	cfg, err := config.LoadConfig(h.configPath)
+	if err != nil {
+		return ""
+	}
+	return cfg.Channels.Pico.Token.String()
 }
 
 // handleWebSocketProxy wraps a reverse proxy to handle WebSocket connections.
@@ -54,23 +99,29 @@ func (h *Handler) handleWebSocketProxy(proxy *httputil.ReverseProxy) http.Handle
 	}
 }
 
-// handleGetPicoToken returns the current WS token and URL for the frontend.
+// handleGetPicoInfo returns non-secret Pico connection info for the launcher UI.
+// The token is deliberately omitted: the WebSocket proxy attaches it server-side
+// (see createWsProxy), so no client ever needs to hold it.
 //
-//	GET /api/pico/token
-func (h *Handler) handleGetPicoToken(w http.ResponseWriter, r *http.Request) {
+//	GET /api/pico/info
+func (h *Handler) handleGetPicoInfo(w http.ResponseWriter, r *http.Request) {
 	cfg, err := config.LoadConfig(h.configPath)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to load config: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	wsURL := h.buildWsURL(r)
+	h.writePicoInfoResponse(w, r, cfg.Channels.Pico.Enabled)
+}
 
+// writePicoInfoResponse writes the shared Pico info payload. It exists so that
+// every response shape on this surface is produced in one place — adding the
+// token back would require editing this function, not one of several handlers.
+func (h *Handler) writePicoInfoResponse(w http.ResponseWriter, r *http.Request, enabled bool) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
-		"token":   cfg.Channels.Pico.Token.String(),
-		"ws_url":  wsURL,
-		"enabled": cfg.Channels.Pico.Enabled,
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ws_url":  h.buildWsURL(r),
+		"enabled": enabled,
 	})
 }
 
@@ -96,13 +147,11 @@ func (h *Handler) handleRegenPicoToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wsURL := h.buildWsURL(r)
+	// Deliberately not returned to the caller: the proxy reads the new token
+	// from config on the next handshake.
+	_ = token
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
-		"token":  token,
-		"ws_url": wsURL,
-	})
+	h.writePicoInfoResponse(w, r, cfg.Channels.Pico.Enabled)
 }
 
 // ensurePicoChannel enables the Pico channel with sane defaults if it isn't

--- a/web/backend/api/pico_test.go
+++ b/web/backend/api/pico_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
@@ -506,5 +509,146 @@ func TestHandlePicoSetup_RejectsSecFetchSiteNoneWithForeignOrigin(t *testing.T) 
 		if len(cfg.Channels.Pico.AllowOrigins) > 0 {
 			t.Errorf("Sec-Fetch-Site: none with foreign Origin must not plant origin; got %v", cfg.Channels.Pico.AllowOrigins)
 		}
+	}
+}
+
+// --- Token confinement -------------------------------------------------------
+//
+// The Pico token authenticates the WebSocket handshake. It must never reach a
+// browser: the launcher proxies /pico/ws and attaches the token server-side.
+// The tests below assert the token is absent from every response body and that
+// the proxy neither trusts a client-supplied token nor echoes the server's own.
+
+// picoConfigWithToken writes a config with the Pico channel enabled and a known
+// token, returning the config path and the token value.
+func picoConfigWithToken(t *testing.T) (string, string) {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	h := NewHandler(configPath)
+	if _, err := h.ensurePicoChannel(""); err != nil {
+		t.Fatalf("ensurePicoChannel() error = %v", err)
+	}
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	token := cfg.Channels.Pico.Token.String()
+	if token == "" {
+		t.Fatal("setup produced an empty token; the test would pass vacuously")
+	}
+	return configPath, token
+}
+
+func TestHandleGetPicoInfo_OmitsToken(t *testing.T) {
+	configPath, token := picoConfigWithToken(t)
+	h := NewHandler(configPath)
+
+	req := httptest.NewRequest("GET", "http://launcher.local/api/pico/info", nil)
+	rec := httptest.NewRecorder()
+	h.handleGetPicoInfo(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, token) {
+		t.Errorf("GET /api/pico/info leaked the Pico token in its body: %s", body)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if _, present := payload["token"]; present {
+		t.Error(`response carries a "token" field; it must not exist at all`)
+	}
+	// Guard against the endpoint becoming useless rather than merely safe.
+	if payload["ws_url"] == "" || payload["ws_url"] == nil {
+		t.Error("response omitted ws_url, so the client cannot connect")
+	}
+	if enabled, ok := payload["enabled"].(bool); !ok || !enabled {
+		t.Error("response omitted enabled=true for an enabled channel")
+	}
+}
+
+func TestHandleRegenPicoToken_OmitsToken(t *testing.T) {
+	configPath, oldToken := picoConfigWithToken(t)
+	h := NewHandler(configPath)
+
+	req := httptest.NewRequest("POST", "http://launcher.local/api/pico/token", nil)
+	req.Header.Set("Origin", "http://launcher.local")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rec := httptest.NewRecorder()
+	h.handleRegenPicoToken(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	newToken := cfg.Channels.Pico.Token.String()
+	if newToken == oldToken {
+		t.Fatal("regen did not rotate the token; the leak assertion below would be vacuous")
+	}
+	if strings.Contains(rec.Body.String(), newToken) {
+		t.Errorf("POST /api/pico/token leaked the new token: %s", rec.Body.String())
+	}
+}
+
+// TestWsProxy_AttachesServerTokenAndDiscardsClientSupplied asserts the two
+// halves of the proxy contract: the gateway receives the token from config, and
+// a token the caller tried to supply is dropped rather than forwarded.
+func TestWsProxy_AttachesServerTokenAndDiscardsClientSupplied(t *testing.T) {
+	configPath, token := picoConfigWithToken(t)
+
+	var gotProtocol string
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProtocol = r.Header.Get(picoProtocolHeader)
+		// Echo it back the way the real Pico channel does, so ModifyResponse
+		// has something to strip.
+		w.Header().Set(picoProtocolHeader, gotProtocol)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gateway.Close()
+
+	gatewayURL, err := url.Parse(gateway.URL)
+	if err != nil {
+		t.Fatalf("parse gateway URL: %v", err)
+	}
+	port, err := strconv.Atoi(gatewayURL.Port())
+	if err != nil {
+		t.Fatalf("parse gateway port: %v", err)
+	}
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.Gateway.Port = port
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	h := NewHandler(configPath)
+	proxy := h.createWsProxy()
+
+	req := httptest.NewRequest("GET", "http://launcher.local/pico/ws", nil)
+	req.Header.Set(picoProtocolHeader, "token.attacker-supplied-value")
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	if gotProtocol != picoTokenSubprotocol+token {
+		t.Errorf("gateway saw subprotocol %q, want %q", gotProtocol, picoTokenSubprotocol+token)
+	}
+	if strings.Contains(gotProtocol, "attacker-supplied-value") {
+		t.Error("proxy forwarded a client-supplied token to the gateway")
+	}
+	if got := rec.Header().Get(picoProtocolHeader); got != "" {
+		t.Errorf("proxy echoed subprotocol %q to the client; it must be stripped", got)
+	}
+	if strings.Contains(rec.Body.String(), token) {
+		t.Error("proxy response body leaked the token")
 	}
 }

--- a/web/frontend/src/api/pico.ts
+++ b/web/frontend/src/api/pico.ts
@@ -1,7 +1,8 @@
 // API client for Pico Channel configuration.
 
-interface PicoTokenResponse {
-  token: string
+// Deliberately has no `token` field. The launcher proxies /pico/ws and attaches
+// the Pico token server-side, so the browser never holds it.
+interface PicoInfoResponse {
   ws_url: string
   enabled: boolean
 }
@@ -22,16 +23,16 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json() as Promise<T>
 }
 
-export async function getPicoToken(): Promise<PicoTokenResponse> {
-  return request<PicoTokenResponse>("/api/pico/token")
+export async function getPicoInfo(): Promise<PicoInfoResponse> {
+  return request<PicoInfoResponse>("/api/pico/info")
 }
 
-export async function regenPicoToken(): Promise<PicoTokenResponse> {
-  return request<PicoTokenResponse>("/api/pico/token", { method: "POST" })
+export async function regenPicoToken(): Promise<PicoInfoResponse> {
+  return request<PicoInfoResponse>("/api/pico/token", { method: "POST" })
 }
 
 export async function setupPico(): Promise<PicoSetupResponse> {
   return request<PicoSetupResponse>("/api/pico/setup", { method: "POST" })
 }
 
-export type { PicoTokenResponse, PicoSetupResponse }
+export type { PicoInfoResponse, PicoSetupResponse }

--- a/web/frontend/src/features/chat/controller.ts
+++ b/web/frontend/src/features/chat/controller.ts
@@ -1,7 +1,7 @@
 import { getDefaultStore } from "jotai"
 import { toast } from "sonner"
 
-import { getPicoToken } from "@/api/pico"
+import { getPicoInfo } from "@/api/pico"
 import {
   loadSessionMessages,
   mergeHistoryMessages,
@@ -130,7 +130,7 @@ export async function connectChat() {
   updateChatStore({ connectionState: "connecting" })
 
   try {
-    const { token } = await getPicoToken()
+    const { enabled } = await getPicoInfo()
     const sessionId = activeSessionIdRef
 
     if (generation !== connectionGeneration) {
@@ -138,18 +138,20 @@ export async function connectChat() {
       return
     }
 
-    if (!token) {
-      console.error("No pico token available")
+    if (!enabled) {
+      console.error("Pico channel is not enabled")
       updateChatStore({ connectionState: "error" })
       isConnecting = false
       scheduleReconnect(generation, sessionId)
       return
     }
 
+    // No subprotocol is offered: the launcher proxy attaches the Pico token
+    // server-side, so the browser never holds or sends it.
     const wsScheme = window.location.protocol === "https:" ? "wss:" : "ws:"
     const wsUrl = `${wsScheme}//${window.location.host}/pico/ws`
     const url = `${wsUrl}?session_id=${encodeURIComponent(sessionId)}`
-    const socket = new WebSocket(url, [`token.${token}`])
+    const socket = new WebSocket(url)
 
     if (generation !== connectionGeneration) {
       isConnecting = false


### PR DESCRIPTION
Ports upstream `4b76196e`, identified as Tier A in the pre-v0.2.7 backfill triage.

## What this adds

The Pico channel authenticates its WebSocket handshake with a `token.<value>` subprotocol.
`GET /api/pico/token` returned that token in its response body, and `POST /api/pico/token` returned
the rotated one — so the browser fetched the token and offered it as a subprotocol itself. The token
lived in JS memory, in fetch buffers, and in anything that records responses: devtools, browser
extensions, HAR exports.

This confines it to the server:

- **`GET /api/pico/token` → `GET /api/pico/info`**, returning `ws_url` and `enabled` and no token.
  `POST /api/pico/token` still rotates the token but returns the same token-free payload.
- **`createWsProxy` attaches the subprotocol server-side**, read from config per request — so a
  rotated token takes effect without restarting the launcher.
- **Client-supplied subprotocols are deleted before forwarding**, so a caller cannot present a token
  of its own choosing to the gateway.
- **The gateway's echoed subprotocol is stripped from the response.** Removed rather than rewritten:
  RFC 6455 requires the server's chosen subprotocol to be one the client offered, and the client now
  offers none, so any value would fail the browser's handshake check.

## Safety-relevant properties

**This is confinement, not an authentication boundary — state it narrowly.** `/pico/ws` is already
gated by the launcher session/password middleware (`apiRequiresAuth`, `web/backend/middleware/auth.go`),
and that gate is what stops unauthenticated access. The exposure closed here is specifically
*token-in-response-body*, not an open socket. Anyone who can read `config.json` still has the token.

**Breaking API change, deliberately.** `GET /api/pico/token` is removed rather than deprecated —
leaving it in place would leave the leak reachable, so it would not close the finding. Every caller
in the tree was enumerated and updated: `web/frontend/src/api/pico.ts`,
`web/frontend/src/features/chat/controller.ts`. `POST /api/pico/token` (rotate) is unchanged in path
and keeps its CSRF gate. No Go caller outside `web/backend/api` existed.

## How it was tested

Three new tests in `web/backend/api/pico_test.go`, each asserting the token is *absent* rather than
that a route returns 200:

| Test | Asserts |
|---|---|
| `TestHandleGetPicoInfo_OmitsToken` | body does not contain the token value, has no `token` key, and still carries usable `ws_url`/`enabled` |
| `TestHandleRegenPicoToken_OmitsToken` | rotation happened (guards against a vacuous assertion) and the new token is not in the body |
| `TestWsProxy_AttachesServerTokenAndDiscardsClientSupplied` | gateway receives the config token; an attacker-supplied subprotocol is dropped; the echoed header is stripped |

**Mutation-verified** — each control was broken and the expected test failed:

| Mutation | Result |
|---|---|
| Put `token` back in the info payload | `TestHandleGetPicoInfo_OmitsToken` **and** `TestHandleRegenPicoToken_OmitsToken` fail |
| Trust the client-supplied subprotocol instead of replacing it | fails: *"proxy forwarded a client-supplied token to the gateway"* |
| Stop stripping the echoed response subprotocol | fails: *"proxy echoed subprotocol \"token.f02b…\" to the client"* |

Full battery on the branch tip with CI's toolchain (`GOTOOLCHAIN=go1.25.13`, after `go generate ./...`):

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go test ./...` | **6346 passed, 0 failed**, 105 packages |
| `golangci-lint` v2.10.1 (CI-pinned) | **0 issues** |
| `govulncheck` v1.1.4 | 0 affecting our code |
| `tsc -b` (frontend, pnpm install first) | **exit 0, no diagnostics** |

## Known limitations

- **CI does not build the frontend** — `pr.yml` runs Go checks only. The TypeScript changes were
  typechecked locally with `tsc -b`, but no CI check will catch a future regression there.
- **No end-to-end test of the handshake.** The proxy test uses an `httptest` gateway that echoes the
  subprotocol; it does not exercise a real WebSocket upgrade against `pkg/channels/pico`.
- **`regenPicoToken` in the frontend is now unused** (it was already unreferenced before this change).
  Left in place rather than removed — out of scope.
- Does not port upstream's `validPicoProxyOrigin` / `canonicalOrigin` origin validation from the same
  commit. That is a separate concern and overlaps `isSameLauncherRequestOrigin` from #65; it needs
  its own review to avoid two origin checks with different rules on the same path.
- Upstream `f8190f04` (stop pinning Pico WebSocket origins during setup) touches the same file and
  remains unported; it should land as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN