### PR TITLE
feat(tools): validate tool arguments against their schema before execution

### DIFF
--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -206,6 +206,17 @@ func (r *ToolRegistry) ExecuteWithContext(
 		return ErrorResult(fmt.Sprintf("tool %q not found", name)).WithError(fmt.Errorf("tool not found"))
 	}
 
+	// Validate arguments against the tool's declared schema before running it.
+	// A model can emit a wrong type or omit a required field; without this the
+	// tool sees the malformed args and fails somewhere less legible, or worse,
+	// coerces them silently.
+	if err := validateToolArgs(tool.Parameters(), args); err != nil {
+		logger.WarnCF("tool", "Tool argument validation failed",
+			map[string]any{"tool": name, "error": err.Error()})
+		return ErrorResult(fmt.Sprintf("invalid arguments for tool %q: %s", name, err)).
+			WithError(fmt.Errorf("argument validation failed: %w", err))
+	}
+
 	// Inject channel/chatID into ctx so tools read them via ToolChannel(ctx)/ToolChatID(ctx).
 	// Always inject — tools validate what they require.
 	ctx = WithToolContext(ctx, channel, chatID)

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -214,6 +214,13 @@ func (t *ExecTool) Parameters() map[string]any {
 			},
 		},
 		"required": []string{"command"},
+		// Opt in to strict argument checking. The schema-validation default in
+		// this tree is permissive about unnamed properties (see
+		// allowsAdditional in validate.go), because models routinely add
+		// harmless extras and rejecting them would break working calls across
+		// every tool. exec is the one tool where an unexpected argument is
+		// worth refusing outright rather than ignoring.
+		"additionalProperties": false,
 	}
 }
 

--- a/pkg/tools/validate.go
+++ b/pkg/tools/validate.go
@@ -1,0 +1,219 @@
+package tools
+
+import (
+	"fmt"
+	"math"
+)
+
+// validateToolArgs validates args against a JSON Schema-like map.
+// schema is expected to have optional keys: "properties", "required", "additionalProperties".
+func validateToolArgs(schema map[string]any, args map[string]any) error {
+	if len(schema) == 0 {
+		return nil
+	}
+
+	if args == nil {
+		args = map[string]any{}
+	}
+
+	if err := checkRequired(schema, args); err != nil {
+		return err
+	}
+
+	propsRaw, ok := schema["properties"]
+	if !ok {
+		return nil // no properties defined — accept any args
+	}
+
+	props, ok := propsRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	additional := allowsAdditional(schema)
+
+	for key, val := range args {
+		propSchemaRaw, known := props[key]
+		if !known {
+			if !additional {
+				return fmt.Errorf("unexpected property %q", key)
+			}
+			continue
+		}
+		propSchema, ok := propSchemaRaw.(map[string]any)
+		if !ok {
+			continue // can't validate without a proper schema map
+		}
+		if err := checkType(key, val, propSchema); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkRequired verifies that every field listed in schema["required"] is present in args.
+func checkRequired(schema map[string]any, args map[string]any) error {
+	reqRaw, ok := schema["required"]
+	if !ok {
+		return nil
+	}
+
+	var required []string
+
+	switch r := reqRaw.(type) {
+	case []string:
+		required = r
+	case []any:
+		for _, v := range r {
+			s, ok := v.(string)
+			if ok {
+				required = append(required, s)
+			}
+		}
+	default:
+		return nil
+	}
+
+	for _, field := range required {
+		if _, present := args[field]; !present {
+			return fmt.Errorf("missing required property %q", field)
+		}
+	}
+	return nil
+}
+
+// allowsAdditional reports whether properties outside the schema are permitted.
+//
+// DIVERGENCE FROM UPSTREAM: upstream rejects extras when the key is absent.
+// No tool schema in this tree — or in upstream's — declares
+// "additionalProperties", so that default rejects every call carrying a field
+// the schema does not name. Models routinely add such fields (an "explanation"
+// alongside the real arguments is common), and those calls work today. Adopting
+// upstream's default would turn them into hard errors across all 83 tools.
+//
+// Absent therefore means permissive here. Type and required-field checking —
+// the part that catches genuinely malformed calls — is unaffected. A tool that
+// wants strictness opts in with "additionalProperties": false.
+func allowsAdditional(schema map[string]any) bool {
+	v, ok := schema["additionalProperties"]
+	if !ok {
+		return true
+	}
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// checkType validates that val matches the JSON Schema type declared in propSchema.
+func checkType(key string, val any, propSchema map[string]any) error {
+	typeRaw, ok := propSchema["type"]
+	if !ok {
+		return nil // no type constraint
+	}
+	typeName, ok := typeRaw.(string)
+	if !ok {
+		return nil
+	}
+
+	switch typeName {
+	case "string":
+		if _, ok := val.(string); !ok {
+			return fmt.Errorf("property %q: expected string, got %T", key, val)
+		}
+	case "integer":
+		switch v := val.(type) {
+		case float64:
+			if v != math.Trunc(v) {
+				return fmt.Errorf("property %q: expected integer, got float64 with fractional part", key)
+			}
+		case int:
+			// ok
+		case int64:
+			// ok
+		default:
+			return fmt.Errorf("property %q: expected integer, got %T", key, val)
+		}
+	case "number":
+		switch val.(type) {
+		case float64, int, int64:
+			// ok
+		default:
+			return fmt.Errorf("property %q: expected number, got %T", key, val)
+		}
+	case "boolean":
+		if _, ok := val.(bool); !ok {
+			return fmt.Errorf("property %q: expected boolean, got %T", key, val)
+		}
+	case "array":
+		arr, ok := val.([]any)
+		if !ok {
+			return fmt.Errorf("property %q: expected array, got %T", key, val)
+		}
+		if err := checkArrayItems(key, arr, propSchema); err != nil {
+			return err
+		}
+	case "object":
+		obj, ok := val.(map[string]any)
+		if !ok {
+			return fmt.Errorf("property %q: expected object, got %T", key, val)
+		}
+		if err := validateToolArgs(propSchema, obj); err != nil {
+			return fmt.Errorf("property %q: %w", key, err)
+		}
+	}
+
+	if err := checkEnum(key, val, propSchema); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkArrayItems validates each element of arr against the "items" sub-schema.
+func checkArrayItems(key string, arr []any, propSchema map[string]any) error {
+	itemsRaw, ok := propSchema["items"]
+	if !ok {
+		return nil
+	}
+	itemSchema, ok := itemsRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for i, elem := range arr {
+		elemKey := fmt.Sprintf("%s[%d]", key, i)
+		if err := checkType(elemKey, elem, itemSchema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkEnum validates that val is one of the allowed enum values in propSchema.
+func checkEnum(key string, val any, propSchema map[string]any) error {
+	enumRaw, ok := propSchema["enum"]
+	if !ok {
+		return nil
+	}
+
+	switch ev := enumRaw.(type) {
+	case []any:
+		for _, allowed := range ev {
+			if val == allowed {
+				return nil
+			}
+		}
+	case []string:
+		s, ok := val.(string)
+		if ok {
+			for _, allowed := range ev {
+				if s == allowed {
+					return nil
+				}
+			}
+		}
+	default:
+		return nil // unknown enum format, skip
+	}
+
+	return fmt.Errorf("property %q: value %v is not in enum", key, val)
+}

--- a/pkg/tools/validate_test.go
+++ b/pkg/tools/validate_test.go
@@ -1,0 +1,531 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Ensure imports are used.
+var (
+	_ = context.Background
+	_ = strings.Contains
+)
+
+func TestValidateToolArgs(t *testing.T) {
+	baseSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+			"age":  map[string]any{"type": "integer"},
+		},
+		"required": []string{"name"},
+	}
+
+	tests := []struct {
+		name    string
+		schema  map[string]any
+		args    map[string]any
+		wantErr string // empty means no error expected
+	}{
+		{
+			name:   "valid args all required present",
+			schema: baseSchema,
+			args:   map[string]any{"name": "alice", "age": float64(30)},
+		},
+		{
+			name:    "missing required field",
+			schema:  baseSchema,
+			args:    map[string]any{"age": float64(30)},
+			wantErr: "missing required property \"name\"",
+		},
+		{
+			name:    "wrong type string field gets number",
+			schema:  baseSchema,
+			args:    map[string]any{"name": float64(42)},
+			wantErr: "expected string",
+		},
+		{
+			name:    "nil args with required fields",
+			schema:  baseSchema,
+			args:    nil,
+			wantErr: "missing required property \"name\"",
+		},
+		{
+			name: "nil args no required fields",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+			args: nil,
+		},
+		{
+			name: "empty args no required fields",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+			args: map[string]any{},
+		},
+		{
+			name:   "optional field correct type",
+			schema: baseSchema,
+			args:   map[string]any{"name": "bob", "age": float64(25)},
+		},
+		{
+			name:    "optional field wrong type",
+			schema:  baseSchema,
+			args:    map[string]any{"name": "bob", "age": "twenty"},
+			wantErr: "expected integer",
+		},
+		{
+			name:   "integer as float64 no fractional part",
+			schema: baseSchema,
+			args:   map[string]any{"name": "carol", "age": float64(42)},
+		},
+		{
+			name:    "actual float for integer field",
+			schema:  baseSchema,
+			args:    map[string]any{"name": "dave", "age": float64(42.5)},
+			wantErr: "expected integer, got float64 with fractional part",
+		},
+		{
+			name: "number type accepts float",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"score": map[string]any{"type": "number"},
+				},
+			},
+			args: map[string]any{"score": float64(3.14)},
+		},
+		{
+			name: "number type accepts integer",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"score": map[string]any{"type": "number"},
+				},
+			},
+			args: map[string]any{"score": float64(10)},
+		},
+		{
+			name: "boolean type valid",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flag": map[string]any{"type": "boolean"},
+				},
+			},
+			args: map[string]any{"flag": true},
+		},
+		{
+			name: "boolean type wrong",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flag": map[string]any{"type": "boolean"},
+				},
+			},
+			args:    map[string]any{"flag": "true"},
+			wantErr: "expected boolean",
+		},
+		{
+			name: "required as []any from MCP deserialization",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"cmd": map[string]any{"type": "string"},
+				},
+				"required": []any{"cmd"},
+			},
+			args:    map[string]any{},
+			wantErr: "missing required property \"cmd\"",
+		},
+		{
+			name: "enum valid value []any",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"color": map[string]any{"type": "string", "enum": []any{"red", "green", "blue"}},
+				},
+			},
+			args: map[string]any{"color": "red"},
+		},
+		{
+			name: "enum invalid value []any",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"color": map[string]any{"type": "string", "enum": []any{"red", "green", "blue"}},
+				},
+			},
+			args:    map[string]any{"color": "yellow"},
+			wantErr: "not in enum",
+		},
+		{
+			name: "enum valid value []string",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"color": map[string]any{"type": "string", "enum": []string{"red", "green", "blue"}},
+				},
+			},
+			args: map[string]any{"color": "green"},
+		},
+		{
+			name: "enum invalid value []string",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"color": map[string]any{"type": "string", "enum": []string{"red", "green", "blue"}},
+				},
+			},
+			args:    map[string]any{"color": "yellow"},
+			wantErr: "not in enum",
+		},
+		{
+			// Rejection is opt-in here: this tree's default is permissive
+			// (see allowsAdditional), so the schema must say so explicitly.
+			name: "extra unexpected property rejected when opted in",
+			schema: map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{"name": map[string]any{"type": "string"}},
+				"required":             []string{"name"},
+				"additionalProperties": false,
+			},
+			args:    map[string]any{"name": "eve", "hobby": "chess"},
+			wantErr: "unexpected property \"hobby\"",
+		},
+		{
+			name:   "extra property allowed when additionalProperties is absent",
+			schema: baseSchema,
+			args:   map[string]any{"name": "eve", "hobby": "chess"},
+		},
+		{
+			name: "extra property allowed with additionalProperties true",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+				"additionalProperties": true,
+			},
+			args: map[string]any{"name": "eve", "hobby": "chess"},
+		},
+		{
+			name: "nested object valid",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"city": map[string]any{"type": "string"},
+						},
+						"required": []string{"city"},
+					},
+				},
+			},
+			args: map[string]any{
+				"address": map[string]any{"city": "Berlin"},
+			},
+		},
+		{
+			name: "nested object wrong type",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"city": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+			args:    map[string]any{"address": "not an object"},
+			wantErr: "expected object",
+		},
+		{
+			name: "array with valid element types",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+			},
+			args: map[string]any{"tags": []any{"a", "b", "c"}},
+		},
+		{
+			name: "array with wrong element types",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+			},
+			args:    map[string]any{"tags": []any{"a", float64(2)}},
+			wantErr: "expected string",
+		},
+		{
+			name: "schema with no properties key accepts any args",
+			schema: map[string]any{
+				"type": "object",
+			},
+			args: map[string]any{"anything": "goes"},
+		},
+		{
+			name:   "empty schema accepts anything",
+			schema: map[string]any{},
+			args:   map[string]any{"foo": "bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateToolArgs(tc.schema, tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateToolArgs_RegistryIntegration(t *testing.T) {
+	r := NewToolRegistry()
+	r.Register(&mockRegistryTool{
+		name: "read_file",
+		desc: "reads a file",
+		params: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{"type": "string"},
+			},
+			"required": []string{"path"},
+		},
+		result: SilentResult("file contents"),
+	})
+
+	// Valid args — should succeed
+	result := r.Execute(context.Background(), "read_file", map[string]any{"path": "/tmp/x"})
+	if result.IsError {
+		t.Errorf("expected success, got error: %s", result.ForLLM)
+	}
+
+	// Missing required field — should fail with validation error
+	result = r.Execute(context.Background(), "read_file", map[string]any{})
+	if !result.IsError {
+		t.Error("expected validation error for missing required field")
+	}
+	if !strings.Contains(result.ForLLM, "missing required p") {
+		t.Errorf("expected 'missing required p...' in error, got %q", result.ForLLM)
+	}
+	if result.Err == nil {
+		t.Error("expected Err to be set via WithError")
+	}
+
+	// Wrong type — should fail with validation error
+	result = r.Execute(context.Background(), "read_file", map[string]any{"path": 123.0})
+	if !result.IsError {
+		t.Error("expected validation error for wrong type")
+	}
+	if !strings.Contains(result.ForLLM, "expected string") {
+		t.Errorf("expected 'expected string' in error, got %q", result.ForLLM)
+	}
+
+	// Extra property — accepted, because read_file takes the permissive default.
+	// Upstream rejects here; see allowsAdditional for why this tree does not.
+	// The call must fail on the missing file, not on argument validation.
+	result = r.Execute(context.Background(), "read_file", map[string]any{"path": "/x", "__inject": true})
+	if strings.Contains(result.ForLLM, "unexpected prop") {
+		t.Errorf("extra property was rejected; the permissive default should allow it: %q", result.ForLLM)
+	}
+}
+
+func TestValidateToolArgs_RealSchemas(t *testing.T) {
+	// Use the real ExecTool schema rather than a copy: this test is named for
+	// real schemas, and a hand-written duplicate silently stops matching the
+	// tool it claims to cover. It also carries exec's opt-in
+	// "additionalProperties": false, which is what the injected-arg case below
+	// actually exercises.
+	execTool, err := NewExecTool(t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("NewExecTool() error = %v", err)
+	}
+	execSchema := execTool.Parameters()
+
+	cronSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type": "string",
+				"enum": []any{"add", "list", "remove", "enable", "disable"},
+			},
+		},
+		"required": []string{"action"},
+	}
+
+	webSearchSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{"type": "string"},
+			"count": map[string]any{"type": "integer"},
+		},
+		"required": []string{"query"},
+	}
+
+	tests := []struct {
+		name    string
+		schema  map[string]any
+		args    map[string]any
+		wantErr string
+	}{
+		// ExecTool
+		{
+			name:   "exec valid args",
+			schema: execSchema,
+			args:   map[string]any{"command": "ls -la", "working_dir": "/tmp"},
+		},
+		{
+			name:    "exec missing required command",
+			schema:  execSchema,
+			args:    map[string]any{"working_dir": "/tmp"},
+			wantErr: "missing required property \"command\"",
+		},
+		{
+			name:    "exec wrong type for command",
+			schema:  execSchema,
+			args:    map[string]any{"command": float64(123)},
+			wantErr: "expected string",
+		},
+		{
+			// exec opts in to strictness, so an unexpected argument is refused
+			// rather than ignored. Every other tool takes the permissive
+			// default — see TestValidateToolArgs_ExtraPropertiesAllowedByDefault.
+			name:    "exec extra injected arg",
+			schema:  execSchema,
+			args:    map[string]any{"command": "ls", "malicious": "payload"},
+			wantErr: "unexpected property \"malicious\"",
+		},
+
+		// CronTool
+		{
+			name:   "cron valid enum value",
+			schema: cronSchema,
+			args:   map[string]any{"action": "add"},
+		},
+		{
+			name:    "cron invalid enum value",
+			schema:  cronSchema,
+			args:    map[string]any{"action": "destroy"},
+			wantErr: "not in enum",
+		},
+
+		// WebSearchTool
+		{
+			name:   "websearch valid args",
+			schema: webSearchSchema,
+			args:   map[string]any{"query": "golang testing", "count": float64(10)},
+		},
+		{
+			name:    "websearch missing required query",
+			schema:  webSearchSchema,
+			args:    map[string]any{"count": float64(5)},
+			wantErr: "missing required property \"query\"",
+		},
+		{
+			name:    "websearch wrong type for count",
+			schema:  webSearchSchema,
+			args:    map[string]any{"query": "test", "count": "ten"},
+			wantErr: "expected integer",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateToolArgs(tc.schema, tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestValidateToolArgs_ExtraPropertiesAllowedByDefault pins this tree's
+// deliberate divergence from upstream picoclaw.
+//
+// Upstream treats an absent "additionalProperties" as "reject extras". No tool
+// schema in either tree declares that key, so upstream's default would reject
+// every call carrying a property the schema does not name — and models
+// routinely add such properties (an "explanation" or "reasoning" field
+// alongside the real arguments). Those calls work today; adopting the strict
+// default would turn them into hard errors across all registered tools.
+//
+// Type and required-field checking, which is what catches genuinely malformed
+// calls, is unaffected by this choice. A tool that wants strictness opts in
+// explicitly, as ExecTool does.
+func TestValidateToolArgs_ExtraPropertiesAllowedByDefault(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{"type": "string"},
+		},
+		"required": []string{"path"},
+	}
+
+	// The shape a model actually emits: correct arguments plus commentary.
+	err := validateToolArgs(schema, map[string]any{
+		"path":        "/tmp/example",
+		"explanation": "reading the file to inspect its contents",
+	})
+	if err != nil {
+		t.Errorf("extra property rejected under the permissive default: %v", err)
+	}
+
+	// The checks that still bite.
+	if err := validateToolArgs(schema, map[string]any{"explanation": "no path"}); err == nil {
+		t.Error("missing required property was accepted; required checking must survive the permissive default")
+	}
+	if err := validateToolArgs(schema, map[string]any{"path": 42.0}); err == nil {
+		t.Error("wrong type was accepted; type checking must survive the permissive default")
+	}
+
+	// Opt-in strictness still works.
+	strict := map[string]any{
+		"type":                 "object",
+		"properties":           map[string]any{"path": map[string]any{"type": "string"}},
+		"additionalProperties": false,
+	}
+	if err := validateToolArgs(strict, map[string]any{"path": "/tmp/x", "extra": 1}); err == nil {
+		t.Error("opt-in strictness did not reject an unexpected property")
+	}
+}


### PR DESCRIPTION
Ports upstream picoclaw `fcc20ec7`, identified as Tier A in the pre-v0.2.7 backfill triage.

## What this adds

`ToolRegistry.ExecuteWithContext` now checks incoming arguments against the tool's declared JSON
schema — required properties, types, enum membership — and returns a structured error instead of
handing malformed arguments to the tool. A model can emit a wrong type or omit a required field;
without this the tool fails somewhere less legible, or coerces the value silently.

`validate.go` and its tests are ported from upstream with the module path rewritten. The registry
hook is 8 lines at the same point upstream uses.

## ⚠️ One deliberate divergence — read this before approving

**Upstream treats an absent `additionalProperties` as "reject extras". This port inverts that
default to permissive.**

Porting it as-is would have been a production regression. **No tool schema in either tree declares
`additionalProperties`** — I checked upstream at `fcc20ec7` as well as our 83 tool files — so
upstream's default rejects *every* call carrying a property the schema does not name. Models
routinely add such properties; an `"explanation"` field alongside the real arguments is the common
case. I confirmed the behaviour by probe before deciding:

```
validateToolArgs(schema, {"path": "/tmp/x", "explanation": "why I did this"})
  → unexpected property "explanation"
```

Those calls work today. Adopting the strict default would turn them into hard errors across every
registered tool, and **no test would have caught it** — the suite sends exact arguments.

**What the port still buys:** type checking and required-field checking are the parts that catch
genuinely malformed calls, and they are entirely unaffected. This is not "ported a validator, then
disabled it".

**`exec` opts back in.** It declares `"additionalProperties": false` explicitly — it is the one tool
where an unexpected argument is worth refusing outright rather than ignoring, so upstream's
injection guard is kept exactly where it earns its cost.

## Safety-relevant properties

- Validation runs **before** the tool executes and before channel/chatID injection, so a rejected
  call never reaches tool code.
- Failures return `ErrorResult` with the reason, and log at warn — visible, not silent.
- `integer` accepts a whole-valued `float64`, which is how JSON numbers arrive from an LLM. Verified
  in `checkType`; a fractional value is still rejected.

## How it was tested

**Mutation-verified** — each of the three controls was broken and the expected test failed:

| Mutation | Result |
|---|---|
| Restore upstream's strict default | `extra property rejected under the permissive default: unexpected property "explanation"` |
| Drop `exec`'s opt-in strictness | `expected error containing "unexpected property \"malicious\"", got nil` |
| Remove the registry hook entirely | `TestValidateToolArgs_RegistryIntegration` fails |

Test changes are additive rather than rewrites, so the diff against upstream's file stays readable:
upstream's extras-rejection cases are kept but given an explicit `"additionalProperties": false`, so
they exercise the same code path; a new test pins the divergence and asserts that required and type
checking survive it.

`TestValidateToolArgs_RealSchemas` now builds its exec schema from `ExecTool.Parameters()` instead
of a hand-written copy. **The copy had already drifted from the tool it claimed to cover** — it
lacked the strictness flag — which is precisely the failure a test with that name exists to prevent.

Full battery on the branch tip with CI's toolchain (`GOTOOLCHAIN=go1.25.13`, after `go generate ./...`):

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go test ./...` | **83 packages ok, 0 failed** |
| `golangci-lint` v2.10.1 (CI-pinned) | **0 issues** |
| `govulncheck` v1.1.4 | 0 affecting our code |

## Known limitations

- **A green suite does not prove real model traffic is safe.** Tests send exact arguments, so they
  cannot detect over-strictness. The `additionalProperties` finding is itself the evidence: I found
  it by probing the validator directly, not from a red test. Other over-strict schemas could exist
  and would surface only as rejected tool calls in production.
- **Schemas are not audited for correctness.** If a tool declares `required` for a field its code
  actually treats as optional, that call is now rejected where it previously worked. I did not audit
  all 83 tools for this; it is a real if narrow risk.
- Field-level constraints beyond type/required/enum (`minimum`, `pattern`, `format`) are not
  enforced — same as upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN