### PR TITLE
ci(pr): build the frontend and a Docker image on pull requests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,6 +65,9 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          # Required: there is no Dockerfile at the repo root, so the default
+          # of "{context}/Dockerfile" resolves to a path that does not exist.
+          file: docker/Dockerfile
           push: true
           tags: |
             ${{ steps.tags.outputs.ghcr_tag }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,3 +61,61 @@ jobs:
 
       - name: Run go test
         run: go test ./...
+
+  frontend:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # Pinned to the major that produced the lockfile (v9 format, pnpm 10.x)
+      # rather than @latest. This job exists to catch lockfile problems, so a
+      # floating package manager that might reject or silently rewrite the
+      # lockfile would undermine the check.
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10 --activate
+
+      # --frozen-lockfile is the point: it fails when the lockfile disagrees
+      # with package.json. A Dependabot PR that regenerated the lockfile without
+      # the pnpm.overrides block passed every existing check while making clean
+      # installs impossible and silently dropping two security pins.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # "pnpm build" is "tsc -b && vite build" — the same command that produces
+      # the dashboard embedded in the Go binary.
+      - name: Typecheck and build
+        run: pnpm build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Builds only; nothing is pushed. docker-build.yml publishes images and
+      # runs on workflow_call at release time, so before this job no PR ever
+      # built an image. That is how a go.mod directive bump to a version newer
+      # than the builder image reached main with three green checks: CI resolves
+      # its toolchain from go.mod, so only an image build sees the mismatch.
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,11 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 COPY --from=builder /src/build/khunquant /usr/local/bin/khunquant
 
 # Run onboard to create initial directories and config
-RUN /usr/local/bin/khunquant onboard
+# --yes is required, not a convenience: onboard prompts for terms acceptance
+# and a credential-encryption passphrase, and a docker build has no TTY, so
+# the bare command dies with "reading passphrase: inappropriate ioctl for
+# device". The flag accepts the terms and skips encryption setup.
+RUN /usr/local/bin/khunquant onboard --yes
 
 ENTRYPOINT ["khunquant"]
 CMD ["gateway"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# Go version pinned to match go.mod (1.26.7) for reproducible builds.
 # This ensures the builder uses exactly what CI tests.
 FROM golang:1.26.7-alpine AS builder
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# Go version pinned to match go.mod (1.26.7) for reproducible builds.
 # This ensures the builder uses exactly what CI tests.
 FROM golang:1.26.7-alpine AS builder
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -40,7 +40,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
 COPY --from=builder /src/build/khunquant /usr/local/bin/khunquant
 
 # Create khunquant home directory
-RUN /usr/local/bin/khunquant onboard
+# --yes is required, not a convenience: onboard prompts for terms acceptance
+# and a credential-encryption passphrase, and a docker build has no TTY, so
+# the bare command dies with "reading passphrase: inappropriate ioctl for
+# device". The flag accepts the terms and skips encryption setup.
+RUN /usr/local/bin/khunquant onboard --yes
 
 ENTRYPOINT ["khunquant"]
 CMD ["gateway"]

--- a/docker/Dockerfile.heavy
+++ b/docker/Dockerfile.heavy
@@ -58,7 +58,11 @@ RUN deluser node 2>/dev/null; delgroup node 2>/dev/null; \
 USER khunquant
 
 # Run onboard to create initial directories and config
-RUN /usr/local/bin/khunquant onboard
+# --yes is required, not a convenience: onboard prompts for terms acceptance
+# and a credential-encryption passphrase, and a docker build has no TTY, so
+# the bare command dies with "reading passphrase: inappropriate ioctl for
+# device". The flag accepts the terms and skips encryption setup.
+RUN /usr/local/bin/khunquant onboard --yes
 
 # Copy default workspace
 COPY --chown=khunquant:khunquant workspace/ /home/khunquant/.khunquant/workspace/

--- a/docker/Dockerfile.heavy
+++ b/docker/Dockerfile.heavy
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Build the khunquant binary
 # ============================================================
-# Go version pinned to match go.mod (1.25.13) for reproducible builds.
+# Go version pinned to match go.mod (1.26.7) for reproducible builds.
 # This ensures the builder uses exactly what CI tests.
 FROM golang:1.26.7-alpine AS builder
 


### PR DESCRIPTION
Closes the gap that let four Dependabot PRs reach review green while broken.

## Why

`pr.yml` runs Go tooling only. Nothing installs, typechecks, or builds the frontend, and
`docker-build.yml` is `workflow_call` — it runs at release time, so **no pull request has ever built
an image**. Two concrete escapes from this sync:

| PR | Broken how | Why every check passed |
|---|---|---|
| [#71](https://github.com/cryptoquantumwave/khunquant/pull/71) | Lockfile regenerated **without the `pnpm.overrides` block**, so `pnpm install --frozen-lockfile` failed and two pins forcing patched transitive deps were silently dropped. Also swept in TypeScript 7, which removed `baseUrl` and broke `tsc -b`. | No job touches the frontend |
| [#70](https://github.com/cryptoquantumwave/khunquant/pull/70) | Moved the `go.mod` directive to 1.26.7 (required by `telego`) while the Dockerfiles pinned `golang:1.25.13-alpine` → every image build fails with `go.mod requires go >= 1.26.7` | CI resolves its toolchain from `go.mod`, so **only an image build sees the mismatch** |

Both were caught by hand. These jobs make that automatic.

## What this adds

**Frontend Build** — frozen install, then `pnpm build` (`tsc -b && vite build`), the same command
that produces the dashboard embedded in the Go binary.

`--frozen-lockfile` is the point: it fails when the lockfile disagrees with `package.json`, which is
exactly #71's first failure. pnpm is pinned to the major that produced the lockfile rather than
`@latest` (the convention in `nightly.yml`) — this job exists to catch lockfile problems, so a
floating package manager that might reject or silently rewrite the lockfile would undermine it.

**Docker Build** — builds `docker/Dockerfile` with buildx, pushes nothing, reusing the same `gha`
cache as the release workflow.

Also corrects the Go version in the three Dockerfile header comments, which still read `1.25.13`
after #77 moved the `FROM` lines to `1.26.7`. That stale comment is mine, from #77.

## How it was tested

The frontend job's exact commands, run on this branch:

| Command | Result |
|---|---|
| `corepack prepare pnpm@10 --activate` + `pnpm install --frozen-lockfile` | **exit 0** |
| `pnpm build` | **exit 0**, built in 709ms |

**The Docker job is not verified locally — no daemon is available in my environment.** Its first run
on this PR is the verification. If it fails, the fix belongs in this PR before merge; please don't
merge on the strength of the other checks.

## Known limitations

- **Neither job is a required check until branch protection says so.** Adding them here makes them
  run and show up; making them *block* merge is a repo settings change I cannot make. Without that,
  this is advisory only.
- **`pnpm lint` is deliberately not included.** It currently reports 14 problems (1 error) on `main`
  — `no-control-regex` for a deliberate `\x1b` in `src/lib/tool-log-parser.ts` — so adding it would
  make CI red immediately. It needs a scoped `eslint-disable` with a comment first. That also means
  the third #71 failure (`typescript-eslint` refusing TS 7) is **not** covered here, though the
  `tsc -b` failure from the same upgrade is.
- **`web/frontend/src/routeTree.gen.ts` is now stale.** Running `pnpm build` regenerates it with 151
  lines of import reordering — output-ordering drift from the `@tanstack/router-plugin` bump in #78.
  Harmless, but it means a `git diff --exit-code` assertion cannot be added to this job until the
  file is regenerated. I left it out rather than bury 302 lines of generated churn in a CI change.
- **Docker build time.** The image compiles the whole Go binary. The `gha` cache should keep repeat
  runs cheap, but the first run will be slow and this does add to PR latency.
- Only `docker/Dockerfile` is built. `Dockerfile.full` and `Dockerfile.heavy` share the same builder
  pin, so the mismatch class is covered, but a break unique to those two would not be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN