### PR TITLE
feat(gateway): wire the pid file into gateway and launcher lifecycle

### DIFF
--- a/cmd/khunquant/internal/gateway/helpers.go
+++ b/cmd/khunquant/internal/gateway/helpers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cryptoquantumwave/khunquant/pkg/heartbeat"
 	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 	"github.com/cryptoquantumwave/khunquant/pkg/media"
+	"github.com/cryptoquantumwave/khunquant/pkg/pid"
 	"github.com/cryptoquantumwave/khunquant/pkg/providers"
 	"github.com/cryptoquantumwave/khunquant/pkg/sandbox"
 	"github.com/cryptoquantumwave/khunquant/pkg/state"
@@ -149,6 +150,18 @@ func gatewayCmd(debug bool) error {
 			"skills_total":     skillsInfo["total"],
 			"skills_available": skillsInfo["available"],
 		})
+
+	// Claim the PID file before starting services. WritePidFile records
+	// os.Getpid(), so it has to run here in the gateway process rather than in
+	// the launcher that spawned it, and it refuses to write when a live gateway
+	// already holds the file. That refusal is the point: without it a launcher
+	// restart forgets the running gateway (it is tracked only by an in-memory
+	// *exec.Cmd) and happily starts a second one on the same port.
+	home := config.HomeDir()
+	if _, err := pid.WritePidFile(home, cfg.Gateway.Host, cfg.Gateway.Port); err != nil {
+		return fmt.Errorf("refusing to start: %w", err)
+	}
+	defer pid.RemovePidFileIfPID(home, os.Getpid())
 
 	// Setup and start all services
 	services, err := setupAndStartServices(cfg, agentLoop, msgBus)

--- a/pkg/pid/pidfile.go
+++ b/pkg/pid/pidfile.go
@@ -15,13 +15,17 @@ import (
 	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 )
 
-const pidFileName = ".picoclaw.pid"
+// pidFileName is the gateway's PID file, written inside config.HomeDir().
+const pidFileName = ".khunquant.pid"
 
 var errInvalidPidFile = errors.New("invalid pid file")
 
 // PidFileData is the JSON structure stored in the PID file.
 type PidFileData struct {
 	PID     int    `json:"pid"`
+	// Token is generated on write but read by nothing today. It exists for a
+	// future launcher↔gateway handshake; until something consumes it, treat it
+	// as reserved rather than as a credential in use.
 	Token   string `json:"token"`
 	Version string `json:"version"`
 	Port    int    `json:"port"`

--- a/pkg/pid/wiring_test.go
+++ b/pkg/pid/wiring_test.go
@@ -1,0 +1,125 @@
+package pid
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover the two properties that justify wiring this package in at
+// all. Until now pkg/pid had unit tests and no callers, so nothing exercised
+// what it is actually for.
+
+// TestWritePidFile_RefusesWhenAnotherLiveGatewayHoldsIt is the singleton
+// guarantee. Without it, a launcher that restarted would forget the gateway it
+// had spawned (it is tracked only by an in-memory *exec.Cmd) and start a second
+// one on the same port.
+//
+// The existing PID must belong to a *different* live process: WritePidFile
+// deliberately lets a process re-claim its own entry, so writing twice from one
+// test process would pass vacuously.
+func TestWritePidFile_RefusesWhenAnotherLiveGatewayHoldsIt(t *testing.T) {
+	home := t.TempDir()
+
+	// A real child, held alive for the duration of the check.
+	other := exec.Command("sleep", "30")
+	if err := other.Start(); err != nil {
+		t.Skipf("cannot spawn a helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = other.Process.Kill()
+		_, _ = other.Process.Wait()
+	})
+
+	entry := fmt.Sprintf(`{"pid":%d,"token":"t","version":"v","port":18790,"host":"127.0.0.1"}`,
+		other.Process.Pid)
+	if err := os.WriteFile(filepath.Join(home, pidFileName), []byte(entry), 0o600); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	if _, err := WritePidFile(home, "127.0.0.1", 18790); err == nil {
+		t.Fatal("WritePidFile() succeeded while another live gateway held the file")
+	} else if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("error = %q, want it to name the running gateway", err.Error())
+	}
+}
+
+// TestWritePidFile_ReclaimsOwnEntry pins the deliberate exception above: a
+// gateway restarting in place must be able to rewrite its own entry rather than
+// deadlock against itself.
+func TestWritePidFile_ReclaimsOwnEntry(t *testing.T) {
+	home := t.TempDir()
+
+	first, err := WritePidFile(home, "127.0.0.1", 18790)
+	if err != nil {
+		t.Fatalf("first WritePidFile() error = %v", err)
+	}
+	if first.PID != os.Getpid() {
+		t.Fatalf("recorded PID = %d, want this process %d", first.PID, os.Getpid())
+	}
+	if _, err := WritePidFile(home, "127.0.0.1", 18790); err != nil {
+		t.Errorf("re-claiming our own entry failed: %v", err)
+	}
+}
+
+// TestReadPidFileWithCheck_FindsGatewayNotSpawnedByUs is the launcher-restart
+// case: the file is on disk from an earlier process and the recorded PID is
+// alive, so the reader must report it.
+func TestReadPidFileWithCheck_FindsGatewayNotSpawnedByUs(t *testing.T) {
+	home := t.TempDir()
+	if _, err := WritePidFile(home, "127.0.0.1", 18790); err != nil {
+		t.Fatalf("WritePidFile() error = %v", err)
+	}
+
+	data := ReadPidFileWithCheck(home)
+	if data == nil {
+		t.Fatal("ReadPidFileWithCheck() = nil; a live gateway went undiscovered")
+	}
+	if data.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", data.PID, os.Getpid())
+	}
+	if data.Port != 18790 {
+		t.Errorf("Port = %d, want 18790", data.Port)
+	}
+}
+
+// TestReadPidFileWithCheck_IgnoresAndRemovesDeadEntry guards the other
+// direction: a stale file must not make a dead gateway look alive, or the
+// launcher would refuse to start one.
+func TestReadPidFileWithCheck_IgnoresAndRemovesDeadEntry(t *testing.T) {
+	home := t.TempDir()
+	if _, err := WritePidFile(home, "127.0.0.1", 18790); err != nil {
+		t.Fatalf("WritePidFile() error = %v", err)
+	}
+
+	// Rewrite the file with a PID that cannot be running. PID 0 is never a
+	// user process, and isProcessRunning must reject it.
+	path := filepath.Join(home, pidFileName)
+	if err := os.WriteFile(path, []byte(`{"pid":0,"token":"t","version":"v","port":18790,"host":"127.0.0.1"}`), 0o600); err != nil {
+		t.Fatalf("rewrite pid file: %v", err)
+	}
+
+	if data := ReadPidFileWithCheck(home); data != nil {
+		t.Fatalf("ReadPidFileWithCheck() = %+v, want nil for a dead PID", data)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("stale pid file was not removed")
+	}
+
+	// With the stale file gone, a fresh gateway can claim the port again.
+	if _, err := WritePidFile(home, "127.0.0.1", 18790); err != nil {
+		t.Errorf("WritePidFile() after stale cleanup error = %v", err)
+	}
+}
+
+// TestPidFileName_IsForkBranded pins the rename. The file is created in the
+// user's home directory, so shipping upstream's name would litter it with a
+// dotfile belonging to a different project.
+func TestPidFileName_IsForkBranded(t *testing.T) {
+	if pidFileName != ".khunquant.pid" {
+		t.Errorf("pidFileName = %q, want .khunquant.pid", pidFileName)
+	}
+}

--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/pid"
 	"github.com/cryptoquantumwave/khunquant/web/backend/utils"
 )
 
@@ -137,7 +138,29 @@ func lookupModelConfig(cfg *config.Config, modelName string) *config.ModelConfig
 }
 
 func isGatewayProcessAliveLocked() bool {
-	return isCmdProcessAliveLocked(gateway.cmd)
+	if isCmdProcessAliveLocked(gateway.cmd) {
+		return true
+	}
+	// No child of ours is alive — but a gateway started by a previous launcher
+	// process may still be running. The launcher tracks the gateway only via an
+	// in-memory *exec.Cmd, so without this the launcher would report "not
+	// running" after its own restart and start a second gateway on the same
+	// port. ReadPidFileWithCheck returns nil for a missing, malformed, or dead
+	// entry and removes the file in the latter two cases.
+	return pid.ReadPidFileWithCheck(config.HomeDir()) != nil
+}
+
+// adoptedGatewayPID returns the PID of a running gateway this launcher did not
+// spawn, or 0. Reported so the dashboard can show a real PID rather than a
+// process it has no handle on.
+func adoptedGatewayPID() int {
+	if isCmdProcessAliveLocked(gateway.cmd) {
+		return 0
+	}
+	if data := pid.ReadPidFileWithCheck(config.HomeDir()); data != nil {
+		return data.PID
+	}
+	return 0
 }
 
 func isCmdProcessAliveLocked(cmd *exec.Cmd) bool {

--- a/web/backend/api/gateway_adopt_test.go
+++ b/web/backend/api/gateway_adopt_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The launcher tracks the gateway only through an in-memory *exec.Cmd, so a
+// launcher restart used to lose it entirely: status reported "not running" and
+// auto-start would have launched a second gateway on the same port. The pid
+// file is what closes that gap, and this is the test for it.
+func TestIsGatewayProcessAliveLocked_AdoptsGatewayFromPidFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KHUNQUANT_HOME", home)
+
+	gateway.mu.Lock()
+	defer gateway.mu.Unlock()
+	prev := gateway.cmd
+	gateway.cmd = nil // as if this launcher had just started
+	t.Cleanup(func() { gateway.cmd = prev })
+
+	// Nothing on disk yet: no gateway anywhere.
+	if isGatewayProcessAliveLocked() {
+		t.Fatal("reported a live gateway with no process and no pid file")
+	}
+	if got := adoptedGatewayPID(); got != 0 {
+		t.Errorf("adoptedGatewayPID() = %d, want 0", got)
+	}
+
+	// A gateway this launcher did not spawn is running and left a pid file.
+	other := exec.Command("sleep", "30")
+	if err := other.Start(); err != nil {
+		t.Skipf("cannot spawn a helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = other.Process.Kill()
+		_, _ = other.Process.Wait()
+	})
+
+	entry := fmt.Sprintf(`{"pid":%d,"token":"t","version":"v","port":18790,"host":"127.0.0.1"}`,
+		other.Process.Pid)
+	if err := os.WriteFile(filepath.Join(home, ".khunquant.pid"), []byte(entry), 0o600); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	if !isGatewayProcessAliveLocked() {
+		t.Error("launcher did not discover a running gateway from the pid file")
+	}
+	if got := adoptedGatewayPID(); got != other.Process.Pid {
+		t.Errorf("adoptedGatewayPID() = %d, want %d", got, other.Process.Pid)
+	}
+}
+
+// A dead entry must not make the launcher believe a gateway is running, or it
+// would refuse to start one and the user would be stuck.
+func TestIsGatewayProcessAliveLocked_IgnoresStalePidFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KHUNQUANT_HOME", home)
+
+	gateway.mu.Lock()
+	defer gateway.mu.Unlock()
+	prev := gateway.cmd
+	gateway.cmd = nil
+	t.Cleanup(func() { gateway.cmd = prev })
+
+	path := filepath.Join(home, ".khunquant.pid")
+	if err := os.WriteFile(path, []byte(`{"pid":0,"token":"t","version":"v","port":18790,"host":"127.0.0.1"}`), 0o600); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	if isGatewayProcessAliveLocked() {
+		t.Error("a stale pid file was treated as a running gateway")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("stale pid file was not cleaned up")
+	}
+}


### PR DESCRIPTION
Resolves **D2** from the sync's remaining-work list: `pkg/pid` existed with tests and **zero callers**.
Wiring it up rather than deleting it.

## The gap it closes

The launcher tracked a running gateway **only through an in-memory `*exec.Cmd`**. So a launcher
restart forgot it entirely: `/api/gateway/status` reported "not running", and `TryAutoStartGateway`
would have launched a **second gateway on the same port**.

## What this does

**The gateway claims the file at startup and releases it on exit.** `WritePidFile` records
`os.Getpid()`, so it has to run in the gateway process, not in the launcher that spawned it — that
constraint decided the whole design. A failure to claim now **aborts startup** rather than being
logged and ignored; refusing to start when another gateway holds the port is the point of the
singleton check.

**Release is a `defer` in the run function**, so it fires on the signal path and *not* on config
reload. I checked this specifically: `shutdownGateway` is reachable only from the `<-sigChan` branch,
and reload calls `stopAndCleanupServices` directly while staying inside the loop — so the file
correctly survives a reload. It uses `RemovePidFileIfPID`, not `RemovePidFile`, so a gateway that
lost a race cannot delete the winner's file.

**The launcher adopts a gateway it did not spawn.** `isGatewayProcessAliveLocked` falls back to
`ReadPidFileWithCheck` when no child of ours is alive — the single chokepoint all three call sites
already use, so status, auto-start, and restart all benefit from one edit. `adoptedGatewayPID`
reports the PID.

**Renames `.picoclaw.pid` → `.khunquant.pid`.** The file is created in the user's home directory, so
shipping upstream's name would leave a dotfile branded for a different project there. Safe to rename
precisely *because* nothing called this package.

**Documents `PidFileData.Token`** — generated on every write and read by nothing. Marked reserved
rather than left looking like a credential in use.

## How it was tested

`pkg/pid`'s existing suite passing proved nothing about integration, since it had no callers. These
are the first tests of the properties the wiring depends on:

| Test | Property |
|---|---|
| `TestWritePidFile_RefusesWhenAnotherLiveGatewayHoldsIt` | a second live gateway is refused |
| `TestWritePidFile_ReclaimsOwnEntry` | a gateway restarting in place is not deadlocked against itself |
| `TestIsGatewayProcessAliveLocked_AdoptsGatewayFromPidFile` | **the motivating case** — a launcher discovers a gateway from a previous process |
| `TestIsGatewayProcessAliveLocked_IgnoresStalePidFile` | a dead entry does not block starting a new gateway, and is cleaned up |

`WritePidFile` deliberately lets a process re-claim its own entry, so the singleton test **spawns a
real second process** — writing twice from one test process would have passed vacuously. I found
that by having the naive version fail.

**Mutation-verified:** removing the launcher's pid-file fallback fails both adoption tests with
`launcher did not discover a running gateway from the pid file`.

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 (CI-pinned) | **0 issues** |

## Known limitations

- **The gateway's own write/release path has no automated test.** It lives in the run function's main
  loop, which no test drives. Removing the `WritePidFile` guard still builds and still passes the
  suite — I confirmed that by mutation. The claim/release behaviour is covered only at the `pkg/pid`
  level; end-to-end coverage would need a gateway harness that does not exist.
- **`isProcessRunning` is PID-based only.** After a reboot and PID reuse, an unrelated process with
  the recycled PID reads as a live gateway. Upstream's `7d167646` adds command-line ownership
  validation for exactly this; it is now separately assessable against a working baseline.
- **No migration for an existing `.picoclaw.pid`.** None can exist — nothing ever wrote one.
- Does not port `0bb56154` (auth token on `/reload`) or `7bf6cbe1` (PID-liveness status downgrade).
  Those extend this baseline and should be judged on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN