### PR TITLE
ci(pr): lint the frontend, catch stale generated files, and stop grouped major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+
+# Majors get their own PRs rather than riding inside a routine group.
+# TypeScript 6 -> 7 arrived this way once and broke tsc, vite build and
+# typescript-eslint at the same time, inside a PR labelled "33 updates".
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
@@ -11,6 +15,9 @@ updates:
       go-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/web/frontend"
@@ -23,6 +30,9 @@ updates:
       frontend-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,6 +45,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/docker"
@@ -47,6 +60,9 @@ updates:
       docker-images:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # The builder image is pinned to the exact toolchain in go.mod (see PR #64),
       # so an automatic bump silently un-aligns the two. Update both together by
@@ -64,3 +80,6 @@ updates:
       docker-compose-images:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,18 @@ jobs:
       - name: Typecheck and build
         run: pnpm build
 
+      # The build regenerates routeTree.gen.ts. Generation is deterministic, so
+      # a diff here means the committed file is stale — which is how a
+      # router-plugin bump silently left it 151 lines out of date.
+      - name: Check generated route tree is current
+        run: git diff --exit-code -- src/routeTree.gen.ts
+
+      # Runs last: it is the least severe failure, and a broken build or a
+      # stale generated file should surface first. This also covers the class
+      # of break where a TypeScript upgrade outruns typescript-eslint.
+      - name: Lint
+        run: pnpm lint
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/web/frontend/src/lib/tool-log-parser.ts
+++ b/web/frontend/src/lib/tool-log-parser.ts
@@ -1,3 +1,7 @@
+// Matches ANSI SGR colour escapes so they can be stripped from tool output.
+// no-control-regex is disabled deliberately: \u001B is the escape character
+// this pattern exists to find, so the rule has nothing useful to say here.
+// eslint-disable-next-line no-control-regex
 const ANSI_PATTERN = /\u001B\[([0-9;]*)m/g
 
 export type ToolCallEntry = {

--- a/web/frontend/src/routeTree.gen.ts
+++ b/web/frontend/src/routeTree.gen.ts
@@ -9,48 +9,28 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as SandboxRouteImport } from './routes/sandbox'
-import { Route as ModelsRouteImport } from './routes/models'
-import { Route as LogsRouteImport } from './routes/logs'
-import { Route as CredentialsRouteImport } from './routes/credentials'
-import { Route as ConfigRouteImport } from './routes/config'
-import { Route as AgentRouteImport } from './routes/agent'
-import { Route as PortfoliosRouteRouteImport } from './routes/portfolios/route'
-import { Route as ChannelsRouteRouteImport } from './routes/channels/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as PortfoliosNameRouteImport } from './routes/portfolios/$name'
-import { Route as ConfigRawRouteImport } from './routes/config.raw'
-import { Route as ChannelsNameRouteImport } from './routes/channels/$name'
-import { Route as AgentToolsRouteImport } from './routes/agent/tools'
-import { Route as AgentSkillsRouteImport } from './routes/agent/skills'
-import { Route as AgentPairingRouteImport } from './routes/agent/pairing'
-import { Route as AgentMemoryRouteImport } from './routes/agent/memory'
-import { Route as AgentCronRouteImport } from './routes/agent/cron'
+import { Route as AgentRouteImport } from './routes/agent'
+import { Route as ChannelsRouteRouteImport } from './routes/channels/route'
+import { Route as ConfigRouteImport } from './routes/config'
+import { Route as CredentialsRouteImport } from './routes/credentials'
+import { Route as LogsRouteImport } from './routes/logs'
+import { Route as ModelsRouteImport } from './routes/models'
+import { Route as PortfoliosRouteRouteImport } from './routes/portfolios/route'
+import { Route as SandboxRouteImport } from './routes/sandbox'
 import { Route as AgentConfigRouteImport } from './routes/agent/config'
+import { Route as AgentCronRouteImport } from './routes/agent/cron'
+import { Route as AgentMemoryRouteImport } from './routes/agent/memory'
+import { Route as AgentPairingRouteImport } from './routes/agent/pairing'
+import { Route as AgentSkillsRouteImport } from './routes/agent/skills'
+import { Route as AgentToolsRouteImport } from './routes/agent/tools'
+import { Route as ChannelsNameRouteImport } from './routes/channels/$name'
+import { Route as ConfigRawRouteImport } from './routes/config.raw'
+import { Route as PortfoliosNameRouteImport } from './routes/portfolios/$name'
 
-const SandboxRoute = SandboxRouteImport.update({
-  id: '/sandbox',
-  path: '/sandbox',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ModelsRoute = ModelsRouteImport.update({
-  id: '/models',
-  path: '/models',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LogsRoute = LogsRouteImport.update({
-  id: '/logs',
-  path: '/logs',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CredentialsRoute = CredentialsRouteImport.update({
-  id: '/credentials',
-  path: '/credentials',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ConfigRoute = ConfigRouteImport.update({
-  id: '/config',
-  path: '/config',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentRoute = AgentRouteImport.update({
@@ -58,54 +38,44 @@ const AgentRoute = AgentRouteImport.update({
   path: '/agent',
   getParentRoute: () => rootRouteImport,
 } as any)
-const PortfoliosRouteRoute = PortfoliosRouteRouteImport.update({
-  id: '/portfolios',
-  path: '/portfolios',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ChannelsRouteRoute = ChannelsRouteRouteImport.update({
   id: '/channels',
   path: '/channels',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const ConfigRoute = ConfigRouteImport.update({
+  id: '/config',
+  path: '/config',
   getParentRoute: () => rootRouteImport,
 } as any)
-const PortfoliosNameRoute = PortfoliosNameRouteImport.update({
-  id: '/$name',
-  path: '/$name',
-  getParentRoute: () => PortfoliosRouteRoute,
+const CredentialsRoute = CredentialsRouteImport.update({
+  id: '/credentials',
+  path: '/credentials',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const ConfigRawRoute = ConfigRawRouteImport.update({
-  id: '/raw',
-  path: '/raw',
-  getParentRoute: () => ConfigRoute,
+const LogsRoute = LogsRouteImport.update({
+  id: '/logs',
+  path: '/logs',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const ChannelsNameRoute = ChannelsNameRouteImport.update({
-  id: '/$name',
-  path: '/$name',
-  getParentRoute: () => ChannelsRouteRoute,
+const ModelsRoute = ModelsRouteImport.update({
+  id: '/models',
+  path: '/models',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const AgentToolsRoute = AgentToolsRouteImport.update({
-  id: '/tools',
-  path: '/tools',
-  getParentRoute: () => AgentRoute,
+const PortfoliosRouteRoute = PortfoliosRouteRouteImport.update({
+  id: '/portfolios',
+  path: '/portfolios',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const AgentSkillsRoute = AgentSkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
-  getParentRoute: () => AgentRoute,
+const SandboxRoute = SandboxRouteImport.update({
+  id: '/sandbox',
+  path: '/sandbox',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const AgentPairingRoute = AgentPairingRouteImport.update({
-  id: '/pairing',
-  path: '/pairing',
-  getParentRoute: () => AgentRoute,
-} as any)
-const AgentMemoryRoute = AgentMemoryRouteImport.update({
-  id: '/memory',
-  path: '/memory',
+const AgentConfigRoute = AgentConfigRouteImport.update({
+  id: '/config',
+  path: '/config',
   getParentRoute: () => AgentRoute,
 } as any)
 const AgentCronRoute = AgentCronRouteImport.update({
@@ -113,10 +83,40 @@ const AgentCronRoute = AgentCronRouteImport.update({
   path: '/cron',
   getParentRoute: () => AgentRoute,
 } as any)
-const AgentConfigRoute = AgentConfigRouteImport.update({
-  id: '/config',
-  path: '/config',
+const AgentMemoryRoute = AgentMemoryRouteImport.update({
+  id: '/memory',
+  path: '/memory',
   getParentRoute: () => AgentRoute,
+} as any)
+const AgentPairingRoute = AgentPairingRouteImport.update({
+  id: '/pairing',
+  path: '/pairing',
+  getParentRoute: () => AgentRoute,
+} as any)
+const AgentSkillsRoute = AgentSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => AgentRoute,
+} as any)
+const AgentToolsRoute = AgentToolsRouteImport.update({
+  id: '/tools',
+  path: '/tools',
+  getParentRoute: () => AgentRoute,
+} as any)
+const ChannelsNameRoute = ChannelsNameRouteImport.update({
+  id: '/$name',
+  path: '/$name',
+  getParentRoute: () => ChannelsRouteRoute,
+} as any)
+const ConfigRawRoute = ConfigRawRouteImport.update({
+  id: '/raw',
+  path: '/raw',
+  getParentRoute: () => ConfigRoute,
+} as any)
+const PortfoliosNameRoute = PortfoliosNameRouteImport.update({
+  id: '/$name',
+  path: '/$name',
+  getParentRoute: () => PortfoliosRouteRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -257,39 +257,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/sandbox': {
-      id: '/sandbox'
-      path: '/sandbox'
-      fullPath: '/sandbox'
-      preLoaderRoute: typeof SandboxRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/models': {
-      id: '/models'
-      path: '/models'
-      fullPath: '/models'
-      preLoaderRoute: typeof ModelsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/logs': {
-      id: '/logs'
-      path: '/logs'
-      fullPath: '/logs'
-      preLoaderRoute: typeof LogsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/credentials': {
-      id: '/credentials'
-      path: '/credentials'
-      fullPath: '/credentials'
-      preLoaderRoute: typeof CredentialsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/config': {
-      id: '/config'
-      path: '/config'
-      fullPath: '/config'
-      preLoaderRoute: typeof ConfigRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agent': {
@@ -299,13 +271,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/portfolios': {
-      id: '/portfolios'
-      path: '/portfolios'
-      fullPath: '/portfolios'
-      preLoaderRoute: typeof PortfoliosRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/channels': {
       id: '/channels'
       path: '/channels'
@@ -313,60 +278,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChannelsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/config': {
+      id: '/config'
+      path: '/config'
+      fullPath: '/config'
+      preLoaderRoute: typeof ConfigRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/portfolios/$name': {
-      id: '/portfolios/$name'
-      path: '/$name'
-      fullPath: '/portfolios/$name'
-      preLoaderRoute: typeof PortfoliosNameRouteImport
-      parentRoute: typeof PortfoliosRouteRoute
+    '/credentials': {
+      id: '/credentials'
+      path: '/credentials'
+      fullPath: '/credentials'
+      preLoaderRoute: typeof CredentialsRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/config/raw': {
-      id: '/config/raw'
-      path: '/raw'
-      fullPath: '/config/raw'
-      preLoaderRoute: typeof ConfigRawRouteImport
-      parentRoute: typeof ConfigRoute
+    '/logs': {
+      id: '/logs'
+      path: '/logs'
+      fullPath: '/logs'
+      preLoaderRoute: typeof LogsRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/channels/$name': {
-      id: '/channels/$name'
-      path: '/$name'
-      fullPath: '/channels/$name'
-      preLoaderRoute: typeof ChannelsNameRouteImport
-      parentRoute: typeof ChannelsRouteRoute
+    '/models': {
+      id: '/models'
+      path: '/models'
+      fullPath: '/models'
+      preLoaderRoute: typeof ModelsRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/agent/tools': {
-      id: '/agent/tools'
-      path: '/tools'
-      fullPath: '/agent/tools'
-      preLoaderRoute: typeof AgentToolsRouteImport
-      parentRoute: typeof AgentRoute
+    '/portfolios': {
+      id: '/portfolios'
+      path: '/portfolios'
+      fullPath: '/portfolios'
+      preLoaderRoute: typeof PortfoliosRouteRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/agent/skills': {
-      id: '/agent/skills'
-      path: '/skills'
-      fullPath: '/agent/skills'
-      preLoaderRoute: typeof AgentSkillsRouteImport
-      parentRoute: typeof AgentRoute
+    '/sandbox': {
+      id: '/sandbox'
+      path: '/sandbox'
+      fullPath: '/sandbox'
+      preLoaderRoute: typeof SandboxRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/agent/pairing': {
-      id: '/agent/pairing'
-      path: '/pairing'
-      fullPath: '/agent/pairing'
-      preLoaderRoute: typeof AgentPairingRouteImport
-      parentRoute: typeof AgentRoute
-    }
-    '/agent/memory': {
-      id: '/agent/memory'
-      path: '/memory'
-      fullPath: '/agent/memory'
-      preLoaderRoute: typeof AgentMemoryRouteImport
+    '/agent/config': {
+      id: '/agent/config'
+      path: '/config'
+      fullPath: '/agent/config'
+      preLoaderRoute: typeof AgentConfigRouteImport
       parentRoute: typeof AgentRoute
     }
     '/agent/cron': {
@@ -376,12 +334,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentCronRouteImport
       parentRoute: typeof AgentRoute
     }
-    '/agent/config': {
-      id: '/agent/config'
-      path: '/config'
-      fullPath: '/agent/config'
-      preLoaderRoute: typeof AgentConfigRouteImport
+    '/agent/memory': {
+      id: '/agent/memory'
+      path: '/memory'
+      fullPath: '/agent/memory'
+      preLoaderRoute: typeof AgentMemoryRouteImport
       parentRoute: typeof AgentRoute
+    }
+    '/agent/pairing': {
+      id: '/agent/pairing'
+      path: '/pairing'
+      fullPath: '/agent/pairing'
+      preLoaderRoute: typeof AgentPairingRouteImport
+      parentRoute: typeof AgentRoute
+    }
+    '/agent/skills': {
+      id: '/agent/skills'
+      path: '/skills'
+      fullPath: '/agent/skills'
+      preLoaderRoute: typeof AgentSkillsRouteImport
+      parentRoute: typeof AgentRoute
+    }
+    '/agent/tools': {
+      id: '/agent/tools'
+      path: '/tools'
+      fullPath: '/agent/tools'
+      preLoaderRoute: typeof AgentToolsRouteImport
+      parentRoute: typeof AgentRoute
+    }
+    '/channels/$name': {
+      id: '/channels/$name'
+      path: '/$name'
+      fullPath: '/channels/$name'
+      preLoaderRoute: typeof ChannelsNameRouteImport
+      parentRoute: typeof ChannelsRouteRoute
+    }
+    '/config/raw': {
+      id: '/config/raw'
+      path: '/raw'
+      fullPath: '/config/raw'
+      preLoaderRoute: typeof ConfigRawRouteImport
+      parentRoute: typeof ConfigRoute
+    }
+    '/portfolios/$name': {
+      id: '/portfolios/$name'
+      path: '/$name'
+      fullPath: '/portfolios/$name'
+      preLoaderRoute: typeof PortfoliosNameRouteImport
+      parentRoute: typeof PortfoliosRouteRoute
     }
   }
 }


### PR DESCRIPTION
Closes the three hygiene items left open after #79. All were found while reviewing Dependabot PRs;
none needed a decision.

## What this does

**Makes `pnpm lint` runnable in CI.** It reported one error on `main` — `no-control-regex` on the
ANSI escape in `tool-log-parser.ts` — which is why #79 had to leave lint out. The escape character
is the very thing that pattern exists to find, so the rule has nothing useful to say there. Scoped
`eslint-disable-next-line` with the reason, not a config-wide exemption. eslint now exits 0
(13 warnings, 0 errors).

**Regenerates `routeTree.gen.ts`**, which had drifted 151 lines out of date since #78's
`@tanstack/router-plugin` bump changed the generator's import ordering.

**Adds two checks to the Frontend Build job:**

- `git diff --exit-code -- src/routeTree.gen.ts` after the build. **Verified the generator is
  deterministic first** — two consecutive builds produce byte-identical output — so this cannot
  flap. Without that check, generated drift is invisible.
- `pnpm lint`, which covers the class of break where a TypeScript upgrade outruns
  `typescript-eslint`. #71 hit exactly that (`typescript-eslint does not support TS 7.0`) and no
  check saw it.

Lint runs last: a broken build or stale generated file is the more severe failure and should surface
first.

**Stops Dependabot groups sweeping in majors.** All five groups used `patterns: ["*"]` with no
`update-types` restriction, so a major could ride inside a routine bump — TypeScript 6→7 arrived
that way in a PR labelled "33 updates" and broke `tsc`, `vite build` and `typescript-eslint` at once
while CI stayed green. Now restricted to `minor` and `patch`. **Majors are still proposed**, as their
own PRs, where the breakage is attributable rather than buried among thirty other lines.

## How it was tested

The extended job's exact commands, run locally in a clean tree:

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `pnpm build` | exit 0 |
| `git diff --exit-code -- src/routeTree.gen.ts` | **exit 0** once the regeneration is committed (exit 1 before — the check works) |
| `pnpm lint` | **exit 0** (13 warnings, 0 errors) |

`.github/dependabot.yml` parsed with `yaml.safe_load`; all five groups confirmed carrying
`update-types: [minor, patch]`.

## Known limitations

- **13 eslint warnings remain**, mostly `react-refresh/only-export-components`. They do not fail the
  job. Fixing them means moving components between files — a refactor, not hygiene, and not
  something to smuggle into a CI change.
- **The drift check only covers `routeTree.gen.ts`.** Other generated output (Go `go generate`
  artifacts) is not checked here.
- **Majors will now arrive as individual PRs, which means more of them.** That is the intended
  trade: more PRs, each one reviewable.
- **These jobs still do not block merge** until branch protection lists `Frontend Build` and
  `Docker Build` as required checks. That is a repo setting I cannot change, and until it is done
  every guard added in #79 and here remains advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN