### PR TITLE
feat(feishu): support Lark by selecting the API domain

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -62,11 +62,15 @@ func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChan
 	)
 
 	tc := newTokenCache()
+	opts := []lark.ClientOptionFunc{lark.WithTokenCache(tc)}
+	if cfg.IsLark {
+		opts = append(opts, lark.WithOpenBaseUrl(lark.LarkBaseUrl))
+	}
 	ch := &FeishuChannel{
 		BaseChannel: base,
 		config:      cfg,
 		tokenCache:  tc,
-		client:      lark.NewClient(cfg.AppID, cfg.AppSecret.String(), lark.WithTokenCache(tc)),
+		client:      lark.NewClient(cfg.AppID, cfg.AppSecret.String(), opts...),
 	}
 	ch.SetOwner(ch)
 	return ch, nil
@@ -91,10 +95,17 @@ func (c *FeishuChannel) Start(ctx context.Context) error {
 
 	c.mu.Lock()
 	c.cancel = cancel
+	// The long-lived event socket has to point at the same deployment as the
+	// REST client above, or events never arrive for an otherwise working bot.
+	domain := lark.FeishuBaseUrl
+	if c.config.IsLark {
+		domain = lark.LarkBaseUrl
+	}
 	c.wsClient = larkws.NewClient(
 		c.config.AppID,
 		c.config.AppSecret.String(),
 		larkws.WithEventHandler(dispatcher),
+		larkws.WithDomain(domain),
 	)
 	wsClient := c.wsClient
 	c.mu.Unlock()

--- a/pkg/channels/feishu/lark_domain_test.go
+++ b/pkg/channels/feishu/lark_domain_test.go
@@ -1,0 +1,58 @@
+package feishu
+
+import (
+	"testing"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/bus"
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+)
+
+// Feishu and Lark are the same product on separate deployments with separate
+// hosts. An app registered on one is not reachable on the other, so pointing at
+// the wrong domain fails authentication outright rather than degrading — which
+// is why the selector has to reach both the REST client and the event socket.
+
+func TestNewFeishuChannel_SelectsDomainFromIsLark(t *testing.T) {
+	// The SDK's exported base URLs are what both call sites switch between;
+	// pin them so a dependency bump that renames or repoints one is caught
+	// here rather than at runtime against a live tenant.
+	if lark.FeishuBaseUrl != "https://open.feishu.cn" {
+		t.Errorf("lark.FeishuBaseUrl = %q, unexpected", lark.FeishuBaseUrl)
+	}
+	if lark.LarkBaseUrl != "https://open.larksuite.com" {
+		t.Errorf("lark.LarkBaseUrl = %q, unexpected", lark.LarkBaseUrl)
+	}
+	if lark.FeishuBaseUrl == lark.LarkBaseUrl {
+		t.Fatal("the two base URLs are identical; the selector would be meaningless")
+	}
+
+	for _, isLark := range []bool{false, true} {
+		cfg := config.FeishuConfig{
+			Enabled:   true,
+			AppID:     "cli_test",
+			AppSecret: *config.NewSecureString("secret"),
+			IsLark:    isLark,
+		}
+		ch, err := NewFeishuChannel(cfg, bus.NewMessageBus())
+		if err != nil {
+			t.Fatalf("NewFeishuChannel(IsLark=%v) error = %v", isLark, err)
+		}
+		if ch.client == nil {
+			t.Fatalf("NewFeishuChannel(IsLark=%v) produced no client", isLark)
+		}
+		if ch.config.IsLark != isLark {
+			t.Errorf("config.IsLark = %v, want %v", ch.config.IsLark, isLark)
+		}
+	}
+}
+
+// The field must survive a config round-trip, or an operator setting it in
+// config.json would see it silently ignored.
+func TestFeishuConfig_IsLarkRoundTrips(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if cfg.Channels.Feishu.IsLark {
+		t.Error("IsLark should default to false (Feishu), not Lark")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -616,6 +616,12 @@ type FeishuConfig struct {
 	Placeholder         PlaceholderConfig   `json:"placeholder,omitempty"   yaml:"-"`
 	ReasoningChannelID  string              `json:"reasoning_channel_id"    yaml:"-" env:"KHUNQUANT_CHANNELS_FEISHU_REASONING_CHANNEL_ID"`
 	RandomReactionEmoji FlexibleStringSlice `json:"random_reaction_emoji"   yaml:"-" env:"KHUNQUANT_CHANNELS_FEISHU_RANDOM_REACTION_EMOJI"`
+	// IsLark selects Lark (open.larksuite.com) instead of Feishu
+	// (open.feishu.cn). Same product, separate deployments with separate
+	// hosts — an app registered on one is not reachable on the other, so
+	// pointing at the wrong domain fails authentication rather than
+	// degrading gracefully.
+	IsLark bool `json:"is_lark" yaml:"-" env:"KHUNQUANT_CHANNELS_FEISHU_IS_LARK"`
 }
 
 type DiscordConfig struct {


### PR DESCRIPTION
Ports upstream picoclaw `08f305d7`. First Tier C item — see the probe note below.

## Why

Feishu and Lark are the same product on **separate deployments with separate hosts**:
`open.feishu.cn` and `open.larksuite.com`. An app registered on one is not reachable on the other,
so a Lark tenant could not use this channel at all — authentication fails outright rather than
degrading.

## What this does

`FeishuConfig.IsLark` selects the domain, and it has to reach **both** call sites:

- the REST client, via `lark.WithOpenBaseUrl(lark.LarkBaseUrl)`
- the long-lived event socket, via `larkws.WithDomain(domain)`

Setting only the first produces a bot whose API calls succeed while **no events ever arrive** — a
failure mode that looks like "the bot is up but ignores me". That is why the field is threaded to
both rather than just the client.

Defaults to `false`, so existing Feishu deployments are unaffected.

## How it was tested

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 (CI-pinned) | **0 issues** |

`TestNewFeishuChannel_SelectsDomainFromIsLark` constructs the channel both ways and pins the SDK's
exported base URLs, so a dependency bump that renames or repoints either constant fails here rather
than at runtime against a live tenant.

**Limitation, stated plainly: the test does not prove the domain took effect.** `lark.Client`
exposes only service structs — there is no readable base-URL field — so no test can assert the
option was applied. What is verified is that the config field plumbs through to both construction
sites and that the two SDK constants are distinct and correct. Actually confirming the request host
needs a live Lark tenant.

## Note on the rest of Tier C

I probed all seven remaining Tier C features before touching any of them, since behavioural
verification has been collapsing this list all along. **This time they are genuinely absent** — whole
features are the case where symbol and directory absence is reliable:

| SHA | Probe |
|---|---|
| `b5ce6209` | no `pkg/channels/vk` |
| `1fc27109` | no teams channel |
| `ed618e14` | no split-marker support |
| `2d855620` | no Telegram quoted-reply handling |
| `48c04e05` | no web_search range mapping |
| `d5c2bc53` | no HTML→Markdown converter |
| `08f305d7` | no `IsLark` — **this PR** |

`08f305d7` is the only one that is not a product decision: we already ship Feishu, and Lark is the
same platform on a different host. The others add new platforms or new surface and should be wanted
before they are built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN