### PR TITLE
feat(web): give dashboard sessions their own identity, and a logout

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,6 +94,12 @@ State-changing launcher endpoints (currently `/api/pico/setup` only) are protect
 ### Known Limitations
 
 - **Spoofed or missing X-Forwarded-For**: If the reverse proxy is misconfigured or omits the `X-Forwarded-For` header, the launcher may fall back to the proxy's own IP, allowing unintended clients to bypass the IP allowlist.
+- **Dashboard sessions can be revoked**: `POST /api/auth/login` exchanges the dashboard password for a session; `POST /api/auth/logout` revokes it. Session IDs are 32 bytes of `crypto/rand`, held server-side, and independent of the launcher secret.
+
+  This replaces a scheme in which the `kq_session` cookie's value **was** the launcher secret. Under that design a captured cookie disclosed the secret itself, and every session was byte-identical — so there was nothing to revoke short of rotating the secret for everyone. An existing test asserted that equality, which is how it stayed in place.
+
+  **Limitations:** sessions live in memory only, so a launcher restart logs everyone out — a deliberate trade for a single local process, not persistence we intended and lost. Sessions expire after 12 hours. HTTP Basic still works as an alternative credential for non-browser clients, so this adds a revocable path rather than removing the unrevocable one; a leaked *password* still requires a hash rotation, and `SessionStore.DestroyAll` exists for that.
+
 - **No per-user authentication**: Authentication is single-password (not per-user). Any client who provides the correct password can perform any operation (modify config, restart agents, etc.).
 - **HTTPS not enforced**: The launcher does not require TLS. If a password is configured, credentials are transmitted via HTTP Basic auth in the request header. Over plain HTTP, these credentials can be intercepted. TLS is strongly recommended when exposing the launcher over a network.
 - **No audit log**: Access is not logged by user or timestamp (though the launcher emits structured request logs). There is no record of who accessed the dashboard or what changes were made.

--- a/web/backend/api/auth_session.go
+++ b/web/backend/api/auth_session.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/cryptoquantumwave/khunquant/web/backend/middleware"
+)
+
+// SetSessionAuth gives the handler what it needs to serve the login and logout
+// endpoints: the session store to mint and revoke in, and the password hash to
+// authenticate against.
+func (h *Handler) SetSessionAuth(store *middleware.SessionStore, passwordHash string) {
+	h.sessions = store
+	h.dashboardPasswordHash = passwordHash
+}
+
+// registerAuthRoutes binds the dashboard session endpoints.
+func (h *Handler) registerAuthRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST "+middleware.LoginPath, h.handleLogin)
+	mux.HandleFunc("POST "+middleware.LogoutPath, h.handleLogout)
+}
+
+// handleLogin exchanges the dashboard password for a session.
+//
+//	POST /api/auth/login
+func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if !allowStateChange(w, r) {
+		return
+	}
+	if h.sessions == nil {
+		http.Error(w, "session auth is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	// No password configured means the dashboard is not password-protected;
+	// minting a session here would invent an authentication step that does not
+	// exist and would let any caller obtain one.
+	if h.dashboardPasswordHash == "" {
+		writeJSONError(w, http.StatusConflict, "no dashboard password is configured")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	if !middleware.VerifyDashboardPassword(h.dashboardPasswordHash, req.Password) {
+		// Deliberately identical to the "no password supplied" case: the
+		// response must not distinguish a wrong password from a malformed one.
+		writeJSONError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	middleware.IssueSessionFor(w, r, h.sessions)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// handleLogout revokes the caller's session.
+//
+//	POST /api/auth/logout
+//
+// This is the capability the previous design could not express: the session
+// cookie used to carry the launcher secret itself, so every session was
+// byte-identical and there was nothing to revoke short of rotating the secret
+// for everyone.
+func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if !allowStateChange(w, r) {
+		return
+	}
+	if h.sessions != nil {
+		if id := middleware.SessionIDFromRequest(r); id != "" {
+			h.sessions.Destroy(id)
+		}
+	}
+	middleware.ClearSessionCookie(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/web/backend/api/auth_session_test.go
+++ b/web/backend/api/auth_session_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/cryptoquantumwave/khunquant/web/backend/middleware"
+)
+
+func newAuthHandler(t *testing.T, password string) (*Handler, *middleware.SessionStore) {
+	t.Helper()
+	h := NewHandler(filepath.Join(t.TempDir(), "config.json"))
+	store := middleware.NewSessionStore(0)
+	hash := ""
+	if password != "" {
+		raw, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("bcrypt: %v", err)
+		}
+		hash = string(raw)
+	}
+	h.SetSessionAuth(store, hash)
+	return h, store
+}
+
+func postJSON(path, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(body)))
+	req.Host = "launcher.local"
+	req.Header.Set("Origin", "http://launcher.local")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	return req
+}
+
+func TestHandleLogin_IssuesSessionForCorrectPassword(t *testing.T) {
+	h, store := newAuthHandler(t, "hunter2")
+
+	rec := httptest.NewRecorder()
+	h.handleLogin(rec, postJSON(middleware.LoginPath, `{"password":"hunter2"}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var id string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName {
+			id = c.Value
+		}
+	}
+	if id == "" {
+		t.Fatal("login issued no session cookie")
+	}
+	if !store.Valid(id) {
+		t.Error("issued cookie does not name a live session")
+	}
+}
+
+func TestHandleLogin_RejectsWrongPassword(t *testing.T) {
+	h, store := newAuthHandler(t, "hunter2")
+
+	rec := httptest.NewRecorder()
+	h.handleLogin(rec, postJSON(middleware.LoginPath, `{"password":"wrong"}`))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if store.Count() != 0 {
+		t.Error("a session was minted for a wrong password")
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName && c.Value != "" {
+			t.Error("a session cookie was set despite failed authentication")
+		}
+	}
+}
+
+// With no password configured the dashboard is not password-protected, so
+// minting a session would invent an authentication step that does not exist and
+// hand one to any caller.
+func TestHandleLogin_RefusesWhenNoPasswordConfigured(t *testing.T) {
+	h, store := newAuthHandler(t, "")
+
+	rec := httptest.NewRecorder()
+	h.handleLogin(rec, postJSON(middleware.LoginPath, `{"password":"anything"}`))
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", rec.Code)
+	}
+	if store.Count() != 0 {
+		t.Error("a session was minted with no password configured")
+	}
+}
+
+// The headline property: logout revokes the caller's session and only theirs.
+func TestHandleLogout_RevokesCallerSessionOnly(t *testing.T) {
+	h, store := newAuthHandler(t, "hunter2")
+
+	mine, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	someoneElse, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+
+	req := postJSON(middleware.LogoutPath, "")
+	req.AddCookie(&http.Cookie{Name: middleware.SessionCookieName, Value: mine})
+	rec := httptest.NewRecorder()
+	h.handleLogout(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if store.Valid(mine) {
+		t.Error("logout did not revoke the caller's session")
+	}
+	if !store.Valid(someoneElse) {
+		t.Error("logout revoked another session as well")
+	}
+
+	var cleared bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("logout did not expire the cookie on the client")
+	}
+}
+
+// Login and logout change server state, so they must carry the same CSRF gate
+// as every other state-changing endpoint.
+func TestAuthEndpoints_RejectCrossSiteRequests(t *testing.T) {
+	h, store := newAuthHandler(t, "hunter2")
+	id, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"login", middleware.LoginPath, h.handleLogin},
+		{"logout", middleware.LogoutPath, h.handleLogout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader([]byte(`{"password":"hunter2"}`)))
+			req.Host = "launcher.local"
+			req.Header.Set("Origin", "http://evil.example")
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.AddCookie(&http.Cookie{Name: middleware.SessionCookieName, Value: id})
+			rec := httptest.NewRecorder()
+			tc.handler(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403", rec.Code)
+			}
+		})
+	}
+	if !store.Valid(id) {
+		t.Error("a cross-site logout revoked the session anyway")
+	}
+}

--- a/web/backend/api/router.go
+++ b/web/backend/api/router.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
 	"github.com/cryptoquantumwave/khunquant/web/backend/launcherconfig"
+	"github.com/cryptoquantumwave/khunquant/web/backend/middleware"
 )
 
 // Handler serves HTTP API requests.
@@ -25,6 +26,8 @@ type Handler struct {
 	oauthFlows                 map[string]*oauthFlow
 	oauthState                 map[string]string
 	updateChecker              *updateChecker
+	sessions                   *middleware.SessionStore
+	dashboardPasswordHash      string
 }
 
 // NewHandler creates an instance of the API handler.
@@ -72,6 +75,9 @@ func (h *Handler) SetDebug(debug bool) {
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Config CRUD
 	h.registerConfigRoutes(mux)
+
+	// Dashboard session endpoints (login / logout)
+	h.registerAuthRoutes(mux)
 
 	// Pico Channel (WebSocket chat)
 	h.registerPicoRoutes(mux)

--- a/web/backend/main.go
+++ b/web/backend/main.go
@@ -155,8 +155,15 @@ func main() {
 		log.Fatalf("Invalid allowed CIDR configuration: %v", err)
 	}
 
+	// One store shared by the session middleware (which validates and issues),
+	// the password middleware (which defers to an established session), and the
+	// API handler (which mints on login and revokes on logout).
+	sessionStore := middleware.NewSessionStore(0)
+	apiHandler.SetSessionAuth(sessionStore, launcherCfg.DashboardPasswordHash)
+
 	// Apply password auth after IP allowlist (both must pass for access).
 	passwordProtectedMux := middleware.PasswordAuth(middleware.PasswordAuthConfig{
+		Sessions:     sessionStore,
 		PasswordHash: launcherCfg.DashboardPasswordHash,
 	}, accessControlledMux)
 
@@ -165,7 +172,7 @@ func main() {
 		middleware.Logger(
 			middleware.SecurityHeaders(
 				middleware.JSONContentType(
-					middleware.SessionAuth(launcherCfg.LauncherToken, passwordProtectedMux),
+					middleware.SessionAuth(launcherCfg.LauncherToken, sessionStore, passwordProtectedMux),
 				),
 			),
 		),

--- a/web/backend/middleware/auth.go
+++ b/web/backend/middleware/auth.go
@@ -21,21 +21,21 @@ const LauncherTokenQueryParam = "launcher_token"
 //
 // SameSite=Strict on the issued cookie blocks CSRF from cross-origin pages: a page
 // from evil.com cannot carry the cookie when reaching back to localhost.
-func SessionAuth(secret string, next http.Handler) http.Handler {
+func SessionAuth(secret string, store *SessionStore, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if hasValidSession(r, secret) {
+		if hasValidSession(r, store) {
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		if isTrustedLoopbackCaller(r) {
-			issueSessionCookie(w, r, secret)
+			issueSessionCookie(w, r, store)
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		if checkRequestToken(r, secret) {
-			issueSessionCookie(w, r, secret)
+			issueSessionCookie(w, r, store)
 			if shouldRedirectAfterQueryToken(r) {
 				http.Redirect(w, r, sanitizedTokenURL(r), http.StatusFound)
 				return
@@ -67,12 +67,32 @@ func apiRequiresAuth(r *http.Request) bool {
 	return r.URL.Path != "/api/health" && r.URL.Path != "/api/ready"
 }
 
-func hasValidSession(r *http.Request, secret string) bool {
-	if secret == "" {
+// hasValidSession consults the session store rather than comparing the cookie
+// to the launcher secret.
+//
+// The previous implementation set the cookie value *to* the secret, so the
+// cookie was a bearer copy of it: one leaked cookie disclosed the secret, and
+// every session was byte-identical and therefore could not be revoked
+// individually. Session IDs are now unguessable and independent of the secret.
+func hasValidSession(r *http.Request, store *SessionStore) bool {
+	if store == nil {
 		return false
 	}
 	c, err := r.Cookie(SessionCookieName)
-	return err == nil && c.Value == secret
+	if err != nil {
+		return false
+	}
+	return store.Valid(c.Value)
+}
+
+// SessionIDFromRequest returns the session ID carried by the request, if any.
+// Used by the logout handler to revoke exactly the caller's own session.
+func SessionIDFromRequest(r *http.Request) string {
+	c, err := r.Cookie(SessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
 }
 
 // isTrustedLoopbackCaller returns true when the IP is loopback and the Origin
@@ -118,15 +138,61 @@ func sanitizedTokenURL(r *http.Request) string {
 	return u.String()
 }
 
-func issueSessionCookie(w http.ResponseWriter, r *http.Request, secret string) {
+// issueSessionCookie mints a fresh session and sets it on the response. The
+// cookie carries a random session ID, never the launcher secret.
+func issueSessionCookie(w http.ResponseWriter, r *http.Request, store *SessionStore) {
+	if store == nil {
+		return
+	}
+	id, err := store.Create()
+	if err != nil {
+		return
+	}
 	secure := r.TLS != nil
 	http.SetCookie(w, &http.Cookie{
 		Name:     SessionCookieName,
-		Value:    secret,
+		Value:    id,
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   secure,
 		SameSite: http.SameSiteStrictMode,
 		Expires:  time.Now().Add(7 * 24 * time.Hour),
 	})
+}
+
+// Paths for the dashboard session endpoints. They live here because both the
+// middleware (which must let the login request through unauthenticated) and the
+// API handler (which serves them) need to agree on the values.
+const (
+	LoginPath  = "/api/auth/login"
+	LogoutPath = "/api/auth/logout"
+)
+
+// ClearSessionCookie expires the session cookie on the client. Pairs with
+// SessionStore.Destroy: the server forgets the session, and the browser stops
+// presenting it.
+func ClearSessionCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1,
+	})
+}
+
+// IssueSessionFor mints a session and sets the cookie. Exported for the login
+// handler, which authenticates by password rather than by the trust rules in
+// SessionAuth.
+func IssueSessionFor(w http.ResponseWriter, r *http.Request, store *SessionStore) {
+	issueSessionCookie(w, r, store)
+}
+
+// VerifyDashboardPassword reports whether plain matches the configured hash.
+// Exported so the login handler can authenticate without duplicating the bcrypt
+// comparison or its fail-closed behaviour.
+func VerifyDashboardPassword(hash, plain string) bool {
+	return verifyPassword(hash, plain)
 }

--- a/web/backend/middleware/auth_test.go
+++ b/web/backend/middleware/auth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSessionAuth_NonLoopbackAPIRequiresToken(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -22,7 +22,7 @@ func TestSessionAuth_NonLoopbackAPIRequiresToken(t *testing.T) {
 }
 
 func TestSessionAuth_QueryTokenIssuesCookieAndRedirects(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -38,13 +38,20 @@ func TestSessionAuth_QueryTokenIssuesCookieAndRedirects(t *testing.T) {
 		t.Fatalf("Location = %q, want %q", got, "/?tab=chat")
 	}
 	cookies := rec.Result().Cookies()
-	if len(cookies) != 1 || cookies[0].Name != SessionCookieName || cookies[0].Value != "secret-token" {
-		t.Fatalf("cookies = %#v, want %s=secret-token", cookies, SessionCookieName)
+	// The cookie must NOT be the secret. This assertion previously required the
+	// opposite, pinning the defect in place: the session cookie carried the
+	// launcher secret verbatim, so capturing one disclosed the secret and every
+	// session was byte-identical and individually unrevocable.
+	if len(cookies) != 1 || cookies[0].Name != SessionCookieName {
+		t.Fatalf("cookies = %#v, want a single %s cookie", cookies, SessionCookieName)
+	}
+	if cookies[0].Value == "secret-token" {
+		t.Fatalf("session cookie carries the launcher secret verbatim")
 	}
 }
 
 func TestSessionAuth_QueryTokenAllowsAPI(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -59,7 +66,7 @@ func TestSessionAuth_QueryTokenAllowsAPI(t *testing.T) {
 }
 
 func TestSessionAuth_LoopbackSameOriginStillAutoAuths(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -76,7 +83,7 @@ func TestSessionAuth_LoopbackSameOriginStillAutoAuths(t *testing.T) {
 }
 
 func TestSessionAuth_PicoWebSocketRequiresToken(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -91,7 +98,7 @@ func TestSessionAuth_PicoWebSocketRequiresToken(t *testing.T) {
 }
 
 func TestSessionAuth_PicoWebSocketWithTokenAllows(t *testing.T) {
-	h := SessionAuth("secret-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := SessionAuth("secret-token", NewSessionStore(0), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/web/backend/middleware/password_auth.go
+++ b/web/backend/middleware/password_auth.go
@@ -9,6 +9,12 @@ import (
 
 // PasswordAuthConfig holds configuration for dashboard password authentication.
 type PasswordAuthConfig struct {
+	// Sessions, when set, lets an authenticated session skip the Basic
+	// challenge. Without it a browser would have to resend credentials on
+	// every request even after logging in, and /api/auth/login could never
+	// be reached to establish a session in the first place.
+	Sessions *SessionStore
+
 	// PasswordHash is the bcrypt hash of the dashboard password.
 	// If empty, password authentication is disabled.
 	PasswordHash string
@@ -29,6 +35,21 @@ func PasswordAuth(cfg PasswordAuthConfig, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks and ready checks.
 		if r.URL.Path == "/api/health" || r.URL.Path == "/api/ready" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// The login endpoint authenticates by password in its own body; it
+		// cannot itself require an existing session or a Basic header.
+		if r.URL.Path == LoginPath {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// An established session stands in for the Basic challenge. Revoking
+		// that session (logout) therefore revokes access, which is the whole
+		// point of having sessions at all.
+		if hasValidSession(r, cfg.Sessions) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/web/backend/middleware/session_auth_test.go
+++ b/web/backend/middleware/session_auth_test.go
@@ -1,0 +1,201 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func hashFor(t *testing.T, pw string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	return string(h)
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+}
+
+// TestSessionCookie_IsNotTheLauncherSecret pins the specific defect this change
+// fixes. The cookie used to carry the launcher secret verbatim, so one captured
+// cookie disclosed the secret itself.
+func TestSessionCookie_IsNotTheLauncherSecret(t *testing.T) {
+	const secret = "launcher-secret-value"
+	store := NewSessionStore(0)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	SessionAuth(secret, store, okHandler()).ServeHTTP(rec, req)
+
+	var cookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == SessionCookieName {
+			cookie = c
+		}
+	}
+	if cookie == nil {
+		t.Fatal("no session cookie issued to a trusted loopback caller")
+	}
+	if cookie.Value == secret {
+		t.Error("session cookie carries the launcher secret verbatim")
+	}
+	if len(cookie.Value) < 32 {
+		t.Errorf("session id %q is too short to be unguessable", cookie.Value)
+	}
+	if !store.Valid(cookie.Value) {
+		t.Error("issued cookie does not name a live session")
+	}
+}
+
+// TestLogout_RevokesOnlyThatSession is the property that did not exist before:
+// per-session identity. Revoking one session must not disturb another.
+func TestLogout_RevokesOnlyThatSession(t *testing.T) {
+	store := NewSessionStore(0)
+
+	a, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	b, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	if a == b {
+		t.Fatal("two sessions share an id; they would be individually unrevocable")
+	}
+	if !store.Valid(a) || !store.Valid(b) {
+		t.Fatal("freshly created sessions are not valid")
+	}
+
+	store.Destroy(a)
+
+	if store.Valid(a) {
+		t.Error("destroyed session is still valid; logout does not revoke")
+	}
+	if !store.Valid(b) {
+		t.Error("destroying one session invalidated another")
+	}
+}
+
+// A revoked session must actually be refused by the middleware, not merely
+// absent from the store.
+func TestSessionAuth_RejectsRevokedSession(t *testing.T) {
+	const secret = "launcher-secret-value"
+	store := NewSessionStore(0)
+	id, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+
+	call := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+		req.RemoteAddr = "203.0.113.5:1234" // not loopback: cookie is the only way in
+		req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: id})
+		rec := httptest.NewRecorder()
+		SessionAuth(secret, store, okHandler()).ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := call(); got != http.StatusOK {
+		t.Fatalf("live session got %d, want 200", got)
+	}
+	store.Destroy(id)
+	if got := call(); got != http.StatusUnauthorized {
+		t.Errorf("revoked session got %d, want 401", got)
+	}
+}
+
+// An expired session must be refused even though it was never explicitly
+// revoked, or an abandoned tab stays a standing credential.
+func TestSessionStore_ExpiresSessions(t *testing.T) {
+	store := NewSessionStore(time.Hour)
+	base := time.Now()
+	store.now = func() time.Time { return base }
+
+	id, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	if !store.Valid(id) {
+		t.Fatal("session invalid immediately after creation")
+	}
+
+	store.now = func() time.Time { return base.Add(time.Hour + time.Minute) }
+	if store.Valid(id) {
+		t.Error("expired session is still valid")
+	}
+}
+
+// Changing the password must not leave existing sessions alive, or a rotation
+// would not actually revoke access.
+func TestSessionStore_DestroyAll(t *testing.T) {
+	store := NewSessionStore(0)
+	ids := make([]string, 3)
+	for i := range ids {
+		id, err := store.Create()
+		if err != nil {
+			t.Fatalf("Create(): %v", err)
+		}
+		ids[i] = id
+	}
+	store.DestroyAll()
+	for _, id := range ids {
+		if store.Valid(id) {
+			t.Errorf("session %s survived DestroyAll", id[:8])
+		}
+	}
+}
+
+// PasswordAuth must accept an established session, or a browser would have to
+// resend Basic credentials on every request and logging in would achieve
+// nothing.
+func TestPasswordAuth_AcceptsEstablishedSession(t *testing.T) {
+	store := NewSessionStore(0)
+	id, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	h := PasswordAuth(PasswordAuthConfig{
+		Sessions:     store,
+		PasswordHash: hashFor(t, "hunter2"),
+	}, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: id})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("session-authenticated request got %d, want 200", rec.Code)
+	}
+
+	// And once revoked, the same request must be challenged again.
+	store.Destroy(id)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusUnauthorized {
+		t.Errorf("revoked session got %d, want 401", rec2.Code)
+	}
+}
+
+// The login path itself must stay reachable without credentials, or there is no
+// way to establish the first session.
+func TestPasswordAuth_AllowsLoginPath(t *testing.T) {
+	h := PasswordAuth(PasswordAuthConfig{
+		Sessions:     NewSessionStore(0),
+		PasswordHash: hashFor(t, "hunter2"),
+	}, okHandler())
+
+	req := httptest.NewRequest(http.MethodPost, LoginPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("login path got %d, want 200 (it must be reachable unauthenticated)", rec.Code)
+	}
+}

--- a/web/backend/middleware/session_store.go
+++ b/web/backend/middleware/session_store.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// DefaultSessionTTL bounds how long a dashboard session stays valid without
+// being re-issued. It is deliberately short enough that an abandoned browser
+// tab stops being a standing credential.
+const DefaultSessionTTL = 12 * time.Hour
+
+// SessionStore holds live dashboard sessions.
+//
+// Sessions live in memory only. They are therefore invalidated wholesale by a
+// launcher restart, which is a deliberate trade rather than an oversight: the
+// launcher is a single local process, persistence would mean shipping a store
+// (web/backend/dashboardauth exists but contains only an unsupported-platform
+// stub), and "restarting the launcher logs everyone out" is defensible
+// behaviour for this kind of tool.
+//
+// What this buys, and what the previous design could not do, is per-session
+// identity: each session has its own unguessable ID, so one can be revoked
+// without disturbing the others.
+type SessionStore struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	sessions map[string]time.Time // id → expiry
+	now      func() time.Time     // overridable in tests
+}
+
+// NewSessionStore returns an empty store. A ttl of zero uses DefaultSessionTTL.
+func NewSessionStore(ttl time.Duration) *SessionStore {
+	if ttl <= 0 {
+		ttl = DefaultSessionTTL
+	}
+	return &SessionStore{
+		ttl:      ttl,
+		sessions: make(map[string]time.Time),
+		now:      time.Now,
+	}
+}
+
+// Create mints a new session and returns its ID.
+//
+// The ID is 32 bytes of crypto/rand, independent of any configured secret. That
+// independence is the point: the previous scheme set the cookie value to the
+// launcher secret itself, so a single leaked cookie disclosed the secret and
+// every session was byte-identical and therefore individually unrevocable.
+func (s *SessionStore) Create() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	id := hex.EncodeToString(raw)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	s.sessions[id] = s.now().Add(s.ttl)
+	return id, nil
+}
+
+// Valid reports whether id names a live session, and is constant-time in the
+// comparison so a caller cannot probe for a valid prefix by timing.
+func (s *SessionStore) Valid(id string) bool {
+	if id == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := s.now()
+	for known, expiry := range s.sessions {
+		if subtle.ConstantTimeCompare([]byte(known), []byte(id)) == 1 {
+			return now.Before(expiry)
+		}
+	}
+	return false
+}
+
+// Destroy invalidates one session. This is what logout does, and it is the
+// capability the old shared-secret cookie could not express.
+func (s *SessionStore) Destroy(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, id)
+}
+
+// DestroyAll invalidates every session, for use when the password changes: a
+// credential rotation that left existing sessions alive would not actually
+// revoke access.
+func (s *SessionStore) DestroyAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions = make(map[string]time.Time)
+}
+
+// Count reports live (unexpired) sessions. Used by tests.
+func (s *SessionStore) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	return len(s.sessions)
+}
+
+func (s *SessionStore) pruneLocked() {
+	now := s.now()
+	for id, expiry := range s.sessions {
+		if !now.Before(expiry) {
+			delete(s.sessions, id)
+		}
+	}
+}


### PR DESCRIPTION
**D1**, per your decision to adopt a session flow. Informed by `06023c79` rather than a direct port —
our auth surface diverged enough that upstream's diff doesn't apply.

## What I found, which is worse than what I described

I told you D1 was "Basic auth has no logout." The actual defect is sharper: **the `kq_session`
cookie's value *was* the launcher secret.**

```go
func hasValidSession(r *http.Request, secret string) bool {
	c, err := r.Cookie(SessionCookieName)
	return err == nil && c.Value == secret   // the cookie IS the secret
}
```

Two consequences. Capturing one session cookie **disclosed the launcher secret itself**. And every
session was byte-identical, so no individual session could be revoked — ending one meant rotating
the secret for everybody.

An existing test asserted that equality (`cookies[0].Value != "secret-token"` → fail), which is how
it stayed in place. That assertion is now inverted.

## What this does

**A real session store.** IDs are 32 bytes of `crypto/rand`, held server-side, independent of the
secret, compared in constant time, expiring after 12 hours. `Destroy` revokes one; `DestroyAll`
exists for a password rotation, which would otherwise leave live sessions behind.

**`POST /api/auth/login`** exchanges the password for a session; **`POST /api/auth/logout`** revokes
the caller's own and expires the cookie. Both carry the same CSRF gate as every other state-changing
endpoint. Login is exempt from the Basic challenge — it authenticates by password in its own body,
so requiring credentials to reach it would leave no way to establish a first session.

**`PasswordAuth` defers to an established session.** Without that a browser would resend Basic
credentials on every request even after logging in, and revoking a session would not revoke access —
which is the entire point.

**Login refuses with 409 when no password is configured**, rather than minting a session. Otherwise
it would invent an authentication step that does not exist and hand one to any caller.

## Deliberate trade

**Sessions are in memory, so a launcher restart logs everyone out.** `web/backend/dashboardauth` was
meant to hold a persistent store but contains only a `mipsle || netbsd || (freebsd && arm)`-tagged
stub — on every real platform it is an empty package imported by nothing. Building it is a separate
project. For a single local process, "restart logs you out" is defensible.

## How it was tested

The tests that earn this assert **revocation**, the property that did not exist:

| Test | Property |
|---|---|
| `TestLogout_RevokesOnlyThatSession` | one session dies, another stays live — proves per-session identity |
| `TestSessionAuth_RejectsRevokedSession` | a revoked session is refused by the middleware, not merely absent from the store |
| `TestPasswordAuth_AcceptsEstablishedSession` | session stands in for Basic, and stops doing so once revoked |
| `TestSessionCookie_IsNotTheLauncherSecret` | the specific defect — one line that would have caught the old design |
| `TestHandleLogin_RejectsWrongPassword` | no session minted, no cookie set |
| `TestAuthEndpoints_RejectCrossSiteRequests` | CSRF gate on both, and a cross-site logout does not revoke |

**Mutation-verified**, all three controls:

| Mutation | Result |
|---|---|
| `hasValidSession` back to a value comparison | `revoked session got 200, want 401` (two tests) |
| Logout stops calling `Destroy` | `logout did not revoke the caller's session` |
| Login accepts any password | `status = 200, want 401` + `a session was minted for a wrong password` |

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 (CI-pinned) | **0 issues** |

## Known limitations

- **HTTP Basic still works** as an alternative credential for non-browser clients. This adds a
  revocable path; it does not remove the unrevocable one. A leaked *password* still needs a hash
  rotation — `DestroyAll` exists for that but nothing calls it yet, because password changes go
  through `launcher-config.json` rather than an endpoint.
- **No frontend.** The endpoints exist and are tested; no login screen calls them. The dashboard
  continues to work via Basic and the loopback path. Wiring the UI is follow-up work.
- **Loopback callers still get an auto-issued session with no password**, unchanged from before.
  That keeps local use working, but it means "has a session" and "proved knowledge of the password"
  remain different things on that path.
- Sessions are not persisted, and there is no "log out everywhere" endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN