### PR TITLE
feat(tools): identify honestly when web_fetch is challenged

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,6 +134,10 @@ State-changing launcher endpoints (currently `/api/pico/setup` only) are protect
 
   **Limitation:** the session guard checks deny patterns only, not the allowlist. Session input is a fragment (a bare `y`, a filename, a continuation line), and matching fragments against whole-command allow patterns would reject ordinary interactive use without adding safety. A command assembled across several `write` calls, each individually innocuous, is not detected — the guard inspects each write in isolation, not the reconstructed line.
 
+- **web_fetch identifies itself when challenged**: outbound web requests present a browser User-Agent by default. When a WAF answers with `403` plus `Cf-Mitigated: challenge`, the request is retried **once** with `khunquant/<version> (+<repo>; AI assistant bot)` — a truthful identifier with a contact URL, which some operators allow-list. A challenge is a request to say who is calling, and the response is to answer it rather than to escalate the disguise.
+
+  Deliberately narrow: only that exact status-and-header pair retries, so an ordinary `403` costs one request rather than two. The browser default itself is unchanged and remains a pre-existing posture choice, not something this behaviour introduces.
+
 - **Non-browser clients can spoof CSRF headers**: A client that is not a web browser (e.g., a custom HTTP client or an attacker's tool) can arbitrarily set `Sec-Fetch-Site`, `Origin`, and `Referer` headers. CSRF protection assumes these headers are set by the browser and cannot be forged; this assumption breaks for non-browser clients. CSRF protection is part of the application-level defense but is **not a substitute for IP allowlist and password authentication**, which govern non-browser access.
 
 ### CSRF Protection Coverage & Special Cases

--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -15,11 +15,18 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 	"github.com/cryptoquantumwave/khunquant/pkg/utils"
 )
 
 const (
 	userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+	// userAgentHonestFormat identifies this agent for its own sake. Used only as
+	// a retry after a WAF challenge: a site that asks who is calling gets a
+	// truthful answer with a contact URL, which some operators allow-list.
+	userAgentHonestFormat = "khunquant/%s (+https://github.com/cryptoquantumwave/khunquant; AI assistant bot)"
 
 	// HTTP client timeouts for web tool providers.
 	searchTimeout     = 10 * time.Second // Brave, Tavily, DuckDuckGo
@@ -915,29 +922,62 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
-	if err != nil {
-		return ErrorResult(fmt.Sprintf("failed to create request: %v", err))
+	doFetch := func(ua string) (*http.Response, []byte, error) {
+		req, reqErr := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+		if reqErr != nil {
+			return nil, nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		allowConfiguredProxyFirstHop(req, t.client.Transport)
+		req.Header.Set("User-Agent", ua)
+
+		resp, doErr := t.client.Do(req)
+		if doErr != nil {
+			return nil, nil, fmt.Errorf("request failed: %w", doErr)
+		}
+		resp.Body = http.MaxBytesReader(nil, resp.Body, t.fetchLimitBytes)
+
+		b, readErr := io.ReadAll(resp.Body)
+		return resp, b, readErr
 	}
-	allowConfiguredProxyFirstHop(req, t.client.Transport)
 
-	req.Header.Set("User-Agent", userAgent)
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return ErrorResult(fmt.Sprintf("request failed: %v", err))
+	resp, body, err := doFetch(userAgent)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
 	}
-
-	resp.Body = http.MaxBytesReader(nil, resp.Body, t.fetchLimitBytes)
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			return ErrorResult(fmt.Sprintf("failed to read response: size exceeded %d bytes limit", t.fetchLimitBytes))
 		}
-		return ErrorResult(fmt.Sprintf("failed to read response: %v", err))
+		return ErrorResult(err.Error())
+	}
+
+	// Cloudflare and similar WAFs signal a bot challenge with 403 plus
+	// "Cf-Mitigated: challenge". Retry once identifying honestly as this agent
+	// rather than as a browser: some operators allow-list AI assistants that say
+	// what they are, and escalating the disguise would be the wrong response to
+	// being asked to identify.
+	//
+	// Narrow on purpose — only that exact status-and-header pair retries, so an
+	// ordinary 403 costs one request, not two.
+	if resp.StatusCode == http.StatusForbidden && resp.Header.Get("Cf-Mitigated") == "challenge" {
+		logger.DebugCF("tool", "Cloudflare challenge detected, retrying with an honest User-Agent",
+			map[string]any{"url": urlStr})
+
+		resp2, body2, err2 := doFetch(honestUserAgent())
+		if resp2 != nil && resp2.Body != nil {
+			defer resp2.Body.Close()
+		}
+		if err2 != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err2, &maxBytesErr) {
+				return ErrorResult(
+					fmt.Sprintf("failed to read response: size exceeded %d bytes limit", t.fetchLimitBytes),
+				)
+			}
+			return ErrorResult(err2.Error())
+		}
+		resp, body = resp2, body2
 	}
 
 	contentType := resp.Header.Get("Content-Type")
@@ -1240,4 +1280,10 @@ func isPrivateOrRestrictedIP(ip net.IP) bool {
 	}
 
 	return false
+}
+
+// honestUserAgent returns the self-identifying User-Agent used when retrying a
+// WAF challenge.
+func honestUserAgent() string {
+	return fmt.Sprintf(userAgentHonestFormat, config.GetVersion())
 }

--- a/pkg/tools/web_honest_ua_test.go
+++ b/pkg/tools/web_honest_ua_test.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// web_fetch presents a browser User-Agent by default. When a WAF answers with a
+// bot challenge, the response is to say honestly what this is rather than to
+// escalate the disguise: some operators allow-list AI assistants that identify
+// themselves, and a challenge is a request for identification.
+
+func fetchToolFor(t *testing.T) *WebFetchTool {
+	t.Helper()
+	// The SSRF pre-flight refuses loopback, which is where httptest lives.
+	withPrivateWebFetchHostsAllowed(t)
+	tool, err := NewWebFetchTool(defaultMaxChars, 1<<20)
+	if err != nil {
+		t.Fatalf("NewWebFetchTool() error = %v", err)
+	}
+	return tool
+}
+
+// TestWebFetch_RetriesChallengeWithHonestUA is the behaviour itself.
+func TestWebFetch_RetriesChallengeWithHonestUA(t *testing.T) {
+	withPrivateWebFetchHostsAllowed(t)
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		seen = append(seen, ua)
+		if len(seen) == 1 {
+			w.Header().Set("Cf-Mitigated", "challenge")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("blocked"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("the real content"))
+	}))
+	defer srv.Close()
+
+	res := fetchToolFor(t).Execute(t.Context(), map[string]any{"url": srv.URL})
+	if res == nil || res.IsError {
+		t.Fatalf("fetch failed: %v", res)
+	}
+	if !strings.Contains(res.ForLLM, "the real content") {
+		t.Errorf("did not return the retried content: %q", res.ForLLM)
+	}
+
+	if len(seen) != 2 {
+		t.Fatalf("made %d requests, want 2 (challenge then honest retry): %v", len(seen), seen)
+	}
+	if seen[0] != userAgent {
+		t.Errorf("first request UA = %q, want the browser default", seen[0])
+	}
+	if !strings.HasPrefix(seen[1], "khunquant/") {
+		t.Errorf("retry UA = %q, want it to identify this agent", seen[1])
+	}
+	if !strings.Contains(seen[1], "AI assistant bot") {
+		t.Errorf("retry UA = %q, want it to say what it is", seen[1])
+	}
+	if strings.Contains(seen[1], "Mozilla") {
+		t.Errorf("retry UA = %q still claims to be a browser", seen[1])
+	}
+}
+
+// A plain 403 with no challenge header must not trigger a second request:
+// retrying every rejection would double traffic to sites that already said no.
+func TestWebFetch_DoesNotRetryPlainForbidden(t *testing.T) {
+	withPrivateWebFetchHostsAllowed(t)
+	var count int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count++
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("no"))
+	}))
+	defer srv.Close()
+
+	_ = fetchToolFor(t).Execute(t.Context(), map[string]any{"url": srv.URL})
+	if count != 1 {
+		t.Errorf("made %d requests to a plain 403, want 1", count)
+	}
+}
+
+// A successful first request must not retry either.
+func TestWebFetch_DoesNotRetryOnSuccess(t *testing.T) {
+	withPrivateWebFetchHostsAllowed(t)
+	var count int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count++
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("fine"))
+	}))
+	defer srv.Close()
+
+	res := fetchToolFor(t).Execute(t.Context(), map[string]any{"url": srv.URL})
+	if res == nil || res.IsError {
+		t.Fatalf("fetch failed: %v", res)
+	}
+	if count != 1 {
+		t.Errorf("made %d requests to a 200, want 1", count)
+	}
+}
+
+// The honest UA must be a truthful identifier, not another disguise.
+func TestHonestUserAgent_IdentifiesTruthfully(t *testing.T) {
+	ua := honestUserAgent()
+	for _, want := range []string{"khunquant/", "AI assistant bot", "https://github.com/"} {
+		if !strings.Contains(ua, want) {
+			t.Errorf("honest UA %q is missing %q", ua, want)
+		}
+	}
+	if strings.Contains(ua, "Mozilla") || strings.Contains(ua, "Chrome") {
+		t.Errorf("honest UA %q impersonates a browser", ua)
+	}
+}


### PR DESCRIPTION
Ports upstream picoclaw `ff975abe`. Per your **"UA: keep browser default"**.

## What this does

`web_fetch` presents a browser User-Agent on every request. When a WAF answers with `403` plus
`Cf-Mitigated: challenge`, it now retries **once** as:

```
khunquant/<version> (+https://github.com/cryptoquantumwave/khunquant; AI assistant bot)
```

A truthful identifier with a contact URL, which some operators explicitly allow-list.

A challenge is a request to say who is calling. Answering it is the right response; escalating the
disguise is not — which is what makes this worth porting rather than, say, rotating browser
fingerprints.

**Deliberately narrow.** Only that exact status-and-header pair retries, so an ordinary `403` costs
one request rather than two, and a site that has already declined is not asked twice.

## What this does not change

The browser User-Agent default stays as it is. That is a **pre-existing posture choice** — five call
sites across every search provider and `web_fetch` — and this change neither introduces nor
ratifies it. `SECURITY.md` says so explicitly so the document does not read as endorsement.

## How it was tested

| Test | Property |
|---|---|
| `TestWebFetch_RetriesChallengeWithHonestUA` | two requests: browser UA, then an honest one carrying `khunquant/` and `AI assistant bot`, and **not** `Mozilla` |
| `TestWebFetch_DoesNotRetryPlainForbidden` | a plain 403 makes exactly **one** request |
| `TestWebFetch_DoesNotRetryOnSuccess` | a 200 makes exactly one request |
| `TestHonestUserAgent_IdentifiesTruthfully` | the honest UA does not impersonate a browser |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| Disable the retry | `made 1 requests, want 2 (challenge then honest retry)` |
| Widen it to any 403 | `made 2 requests to a plain 403, want 1` |

The second matters as much as the first: an over-broad retry is a real cost to sites, not just a
test detail.

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 | **0 issues** |

## Known limitations

- **Only Cloudflare's signal is recognised.** Other WAFs challenge differently (Akamai, AWS WAF) and
  are not detected, so this helps with one vendor rather than bot challenges generally.
- **One retry, no backoff.** If the honest UA is also refused, the 403 is returned as-is — which is
  the correct outcome, but it means two requests were spent to learn it.
- The tests use `withPrivateWebFetchHostsAllowed`, the existing helper, because the SSRF pre-flight
  refuses loopback where `httptest` lives. That is a test-only relaxation of a production guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN