### PR TITLE
feat(channels,agent): let the model mark message boundaries

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cryptoquantumwave/khunquant/pkg/channels"
 	"github.com/cryptoquantumwave/khunquant/pkg/config"
 	"github.com/cryptoquantumwave/khunquant/pkg/logger"
 	"github.com/cryptoquantumwave/khunquant/pkg/providers"
@@ -26,6 +27,7 @@ type ContextBuilder struct {
 	memory             *MemoryStore
 	toolDiscoveryBM25  bool
 	toolDiscoveryRegex bool
+	splitOnMarker      bool
 
 	// Cache for system prompt to avoid rebuilding on every call.
 	// This fixes issue #607: repeated reprocessing of the entire context.
@@ -51,6 +53,14 @@ type ContextBuilder struct {
 func (cb *ContextBuilder) WithToolDiscovery(useBM25, useRegex bool) *ContextBuilder {
 	cb.toolDiscoveryBM25 = useBM25
 	cb.toolDiscoveryRegex = useRegex
+	return cb
+}
+
+// WithSplitOnMarker tells the model it may mark message boundaries. Without
+// this the marker is never emitted and the manager-side split is inert, so the
+// two halves of the feature have to be enabled together.
+func (cb *ContextBuilder) WithSplitOnMarker(enabled bool) *ContextBuilder {
+	cb.splitOnMarker = enabled
 	return cb
 }
 
@@ -159,6 +169,21 @@ func (cb *ContextBuilder) BuildSystemPrompt() string {
 	memoryContext := cb.memory.GetMemoryContext()
 	if memoryContext != "" {
 		parts = append(parts, "# Memory\n\n"+memoryContext)
+	}
+
+	// Multi-message output, when enabled.
+	//
+	// Phrased as a capability rather than an instruction. Upstream's wording
+	// ("You MUST frequently... NEVER output a single long wall of text") pushes
+	// the model to fragment answers that are better whole; a marker is useful
+	// when the content genuinely divides, and harmful when it does not.
+	if cb.splitOnMarker {
+		parts = append(parts, "# Multi-Message Output\n\n"+
+			"You may insert "+channels.MessageSplitMarker+" where a response divides "+
+			"naturally into separate messages — for example distinct steps, or a "+
+			"summary followed by detail. Each part is delivered as its own message.\n\n"+
+			"Use it where the split helps the reader. A single coherent answer should "+
+			"stay a single message.")
 	}
 
 	// Join with "---" separator

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -338,7 +338,7 @@ func NewAgentInstance(
 	contextBuilder := NewContextBuilder(workspace).WithToolDiscovery(
 		mcpDiscoveryActive && cfg.Tools.MCP.Discovery.UseBM25,
 		mcpDiscoveryActive && cfg.Tools.MCP.Discovery.UseRegex,
-	)
+	).WithSplitOnMarker(cfg.Agents.Defaults.SplitOnMarker)
 	if financialCollector != nil {
 		contextBuilder = contextBuilder.WithFinancialCollector(financialCollector)
 	}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -564,6 +564,28 @@ func newChannelWorker(name string, ch Channel) *channelWorker {
 
 // runWorker processes outbound messages for a single channel, splitting
 // messages that exceed the channel's maximum message length.
+// splitOutbound returns the messages to actually send for one outbound
+// message. Always returns at least one element.
+func (m *Manager) splitOutbound(content string, maxLen int) []string {
+	splitByLength := func(s string) []string {
+		if maxLen > 0 && len([]rune(s)) > maxLen {
+			return SplitMessage(s, maxLen)
+		}
+		return []string{s}
+	}
+
+	if m.config != nil && m.config.Agents.Defaults.SplitOnMarker {
+		if parts := SplitByMarker(content); len(parts) > 1 {
+			out := make([]string, 0, len(parts))
+			for _, part := range parts {
+				out = append(out, splitByLength(part)...)
+			}
+			return out
+		}
+	}
+	return splitByLength(content)
+}
+
 func (m *Manager) runWorker(ctx context.Context, name string, w *channelWorker) {
 	defer close(w.done)
 	for {
@@ -576,15 +598,17 @@ func (m *Manager) runWorker(ctx context.Context, name string, w *channelWorker) 
 			if mlp, ok := w.ch.(MessageLengthProvider); ok {
 				maxLen = mlp.MaxMessageLength()
 			}
-			if maxLen > 0 && len([]rune(msg.Content)) > maxLen {
-				chunks := SplitMessage(msg.Content, maxLen)
-				for _, chunk := range chunks {
-					chunkMsg := msg
-					chunkMsg.Content = chunk
-					m.sendWithRetry(ctx, name, w, chunkMsg)
-				}
-			} else {
-				m.sendWithRetry(ctx, name, w, msg)
+			// Two independent splits, applied in order:
+			//  1. the marker, which is the model saying "these are separate
+			//     messages" — a semantic boundary;
+			//  2. the channel's length limit, which is a transport constraint.
+			// Length splitting runs on each marker part, so a long part is still
+			// chunked; doing it the other way round would let a length split
+			// cut across a marker and merge two intended messages.
+			for _, part := range m.splitOutbound(msg.Content, maxLen) {
+				partMsg := msg
+				partMsg.Content = part
+				m.sendWithRetry(ctx, name, w, partMsg)
 			}
 		case <-ctx.Done():
 			return

--- a/pkg/channels/marker.go
+++ b/pkg/channels/marker.go
@@ -1,0 +1,37 @@
+// KhunQuant - Ultra-lightweight personal AI agent
+// Inspired by and based on nanobot: https://github.com/HKUDS/nanobot
+// License: MIT
+//
+// Copyright (c) 2026 KhunQuant contributors
+
+package channels
+
+import (
+	"strings"
+)
+
+// MessageSplitMarker is the delimiter used to split a message into multiple outbound messages.
+// When SplitOnMarker is enabled in config, the Manager will split messages on this marker
+// and send each part as a separate message.
+const MessageSplitMarker = "<|[SPLIT]|>"
+
+// SplitByMarker splits a message by the MessageSplitMarker and returns the parts.
+// Empty parts (including from consecutive markers) are filtered out.
+// If no marker is found, returns a single-element slice containing the original content.
+func SplitByMarker(content string) []string {
+	if content == "" {
+		return nil
+	}
+	parts := strings.Split(content, MessageSplitMarker)
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return []string{content}
+	}
+	return result
+}

--- a/pkg/channels/marker_split_test.go
+++ b/pkg/channels/marker_split_test.go
@@ -1,0 +1,100 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cryptoquantumwave/khunquant/pkg/config"
+)
+
+func TestSplitByMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"no marker", "one message", []string{"one message"}},
+		{"two parts", "first" + MessageSplitMarker + "second", []string{"first", "second"}},
+		{"trims surrounding space", "  first  " + MessageSplitMarker + "  second  ", []string{"first", "second"}},
+		{"drops empty parts", "first" + MessageSplitMarker + "   " + MessageSplitMarker + "second", []string{"first", "second"}},
+		{"empty input", "", nil},
+		// A message that is nothing but markers must not vanish: sending
+		// nothing at all is worse than sending the original.
+		{"only markers", MessageSplitMarker + MessageSplitMarker, []string{MessageSplitMarker + MessageSplitMarker}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SplitByMarker(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("SplitByMarker(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("part %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// splitOutbound is where the two splits meet. The order matters: the marker is
+// the model saying "separate messages", the length limit is a transport
+// constraint, and applying length first could cut across a marker.
+func TestSplitOutbound(t *testing.T) {
+	enabled := &Manager{config: &config.Config{}}
+	enabled.config.Agents.Defaults.SplitOnMarker = true
+	disabled := &Manager{config: &config.Config{}}
+
+	t.Run("disabled ignores the marker", func(t *testing.T) {
+		got := disabled.splitOutbound("a"+MessageSplitMarker+"b", 0)
+		if len(got) != 1 {
+			t.Fatalf("got %d parts, want 1 when the feature is off: %q", len(got), got)
+		}
+		if !strings.Contains(got[0], MessageSplitMarker) {
+			t.Error("the marker was consumed even though splitting is disabled")
+		}
+	})
+
+	t.Run("enabled splits on the marker", func(t *testing.T) {
+		got := enabled.splitOutbound("a"+MessageSplitMarker+"b", 0)
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Fatalf("got %q, want [a b]", got)
+		}
+	})
+
+	t.Run("length splitting still applies within a part", func(t *testing.T) {
+		long := strings.Repeat("x", 25)
+		got := enabled.splitOutbound("short"+MessageSplitMarker+long, 10)
+		if len(got) < 3 {
+			t.Fatalf("got %d parts, want the long part chunked as well: %q", len(got), got)
+		}
+		if got[0] != "short" {
+			t.Errorf("first part = %q, want the short one intact", got[0])
+		}
+		for i, p := range got {
+			if len([]rune(p)) > 10 {
+				t.Errorf("part %d is %d runes, over the limit: %q", i, len([]rune(p)), p)
+			}
+		}
+	})
+
+	t.Run("no marker still length splits", func(t *testing.T) {
+		got := enabled.splitOutbound(strings.Repeat("y", 25), 10)
+		if len(got) < 3 {
+			t.Errorf("got %d parts, want the message chunked: %q", len(got), got)
+		}
+	})
+
+	t.Run("always returns at least one part", func(t *testing.T) {
+		if got := enabled.splitOutbound("", 0); len(got) != 1 {
+			t.Errorf("empty content produced %d parts, want 1", len(got))
+		}
+	})
+
+	t.Run("nil config does not panic", func(t *testing.T) {
+		bare := &Manager{}
+		if got := bare.splitOutbound("a"+MessageSplitMarker+"b", 0); len(got) != 1 {
+			t.Errorf("got %d parts, want 1 with no config", len(got))
+		}
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -519,6 +519,12 @@ type AgentDefaults struct {
 	MaxContextAssets           int                `json:"max_context_assets"              env:"KHUNQUANT_AGENTS_DEFAULTS_MAX_CONTEXT_ASSETS"`
 	MaxContextDCAPlans         int                `json:"max_context_dca_plans"           env:"KHUNQUANT_AGENTS_DEFAULTS_MAX_CONTEXT_DCA_PLANS"`
 	MaxContextDNPlans          int                `json:"max_context_dn_plans"            env:"KHUNQUANT_AGENTS_DEFAULTS_MAX_CONTEXT_DN_PLANS"`
+	// SplitOnMarker lets the model emit <|[SPLIT]|> to mark a boundary between
+	// separate outbound messages, rather than everything arriving as one block.
+	// Off by default: a model that has not been told about the marker will never
+	// emit it, but a message that happens to contain the literal string would
+	// otherwise be split unexpectedly.
+	SplitOnMarker bool `json:"split_on_marker" env:"KHUNQUANT_AGENTS_DEFAULTS_SPLIT_ON_MARKER"`
 }
 
 const DefaultMaxMediaSize = 20 * 1024 * 1024 // 20 MB
@@ -801,9 +807,9 @@ type DevicesConfig struct {
 }
 
 type VoiceConfig struct {
-	EchoTranscription  bool   `json:"echo_transcription" env:"KHUNQUANT_VOICE_ECHO_TRANSCRIPTION"`
-	ModelName          string `json:"model_name,omitempty" env:"KHUNQUANT_VOICE_MODEL_NAME"`
-	ElevenLabsAPIKey   string `json:"elevenlabs_api_key,omitzero" env:"KHUNQUANT_VOICE_ELEVENLABS_API_KEY"`
+	EchoTranscription bool   `json:"echo_transcription" env:"KHUNQUANT_VOICE_ECHO_TRANSCRIPTION"`
+	ModelName         string `json:"model_name,omitempty" env:"KHUNQUANT_VOICE_MODEL_NAME"`
+	ElevenLabsAPIKey  string `json:"elevenlabs_api_key,omitzero" env:"KHUNQUANT_VOICE_ELEVENLABS_API_KEY"`
 }
 
 // DevMCPConfig controls the read-only developer MCP debug server.


### PR DESCRIPTION
Ports upstream picoclaw `ed618e14`. Tier C.

## What this adds

With `agents.defaults.split_on_marker` enabled, a response containing `<|[SPLIT]|>` is delivered as
several messages instead of one block — useful on chat channels, where a long answer arrives as an
unreadable wall.

**Both halves are wired, because either alone is inert.** The manager splits on the marker, and the
system prompt tells the model the marker exists. Without the prompt side the model never emits it
and the split never fires — the exact "shipped an inert fragment" failure this sync hit in wave 2.

## Two decisions

**Split order is marker first, then length.** The marker is the model saying "these are separate
messages"; the length limit is a transport constraint. Length-splitting first could cut across a
marker and merge two intended messages into one.

**Off by default.** A model that has not been told about the marker will never emit it — but a
message that happens to contain the literal string would otherwise be split unexpectedly.

## A deliberate change to upstream's prompt

Upstream's wording is:

> You MUST frequently use `<|[SPLIT]|>` to break your responses into multiple short messages. NEVER
> output a single long wall of text.

That pushes the model to fragment answers that read better whole. Ours describes the marker as
available where a response divides naturally — distinct steps, a summary then detail — and says
explicitly that a single coherent answer should stay a single message.

## How it was tested

| Test | Property |
|---|---|
| `TestSplitByMarker` | trimming, empty parts dropped, and a message of **only** markers returned intact rather than vanishing |
| `TestSplitOutbound/disabled…` | the marker is left alone, not consumed, when the feature is off |
| `TestSplitOutbound/enabled…` | splits into the intended parts |
| `TestSplitOutbound/length splitting still applies…` | a long marker part is still chunked, and no part exceeds the limit |
| `TestSplitOutbound/nil config…` | no panic when the manager has no config |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| Config flag never read | `got ["a<\|[SPLIT]\|>b"], want [a b]` |
| Length split dropped after marker split | the over-limit assertion fails |

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 | **0 issues** |

## Known limitations

- **No frontend toggle.** The setting is config-only; upstream also adds a config-page control,
  which our rebranded UI would need built rather than ported.
- **The prompt is untested.** That it *appears* when enabled is not asserted — only the splitting
  behaviour is. Whether a model actually uses the marker well is a prompt-quality question no unit
  test settles.
- `pkg/agent` now imports `pkg/channels` for the marker constant. Verified no cycle (`pkg/channels`
  does not import `pkg/agent`), but it is a new edge between two large packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN