### PR TITLE
feat(telegram): include quoted reply context in inbound turns

### DIFF
--- a/pkg/channels/telegram/quoted_reply_test.go
+++ b/pkg/channels/telegram/quoted_reply_test.go
@@ -1,0 +1,171 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mymmrac/telego"
+)
+
+// A Telegram reply carries the message it answers. Without that context the
+// agent saw only the new text, so "yes, do that" arrived with no indication of
+// what "that" was.
+
+func TestTelegramQuotedContent_DescribesWhatWasQuoted(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *telego.Message
+		want []string
+	}{
+		{"text", &telego.Message{Text: "the original"}, []string{"the original"}},
+		{"caption", &telego.Message{Caption: "a caption"}, []string{"a caption"}},
+		{"photo", &telego.Message{Photo: []telego.PhotoSize{{FileID: "f"}}}, []string{"[image: photo]"}},
+		{"voice", &telego.Message{Voice: &telego.Voice{FileID: "f"}}, []string{"[voice]"}},
+		{"audio", &telego.Message{Audio: &telego.Audio{FileID: "f"}}, []string{"[audio]"}},
+		{"document", &telego.Message{Document: &telego.Document{FileID: "f"}}, []string{"[file]"}},
+		{
+			"caption alongside media",
+			&telego.Message{Caption: "look at this", Photo: []telego.PhotoSize{{FileID: "f"}}},
+			[]string{"look at this", "[image: photo]"},
+		},
+		{"nil message", nil, nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := telegramQuotedContent(tc.msg)
+			if len(tc.want) == 0 {
+				if got != "" {
+					t.Errorf("got %q, want empty", got)
+				}
+				return
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("got %q, want it to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestTelegramQuotedAuthor_PrefersUsername(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *telego.Message
+		want string
+	}{
+		{"username", &telego.Message{From: &telego.User{Username: "alice", FirstName: "Alice"}}, "alice"},
+		{"falls back to first name", &telego.Message{From: &telego.User{FirstName: "Bob"}}, "Bob"},
+		{"neither", &telego.Message{From: &telego.User{}}, "unknown"},
+		{"no sender", &telego.Message{}, "unknown"},
+		{"nil message", nil, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := telegramQuotedAuthor(tc.msg); got != tc.want {
+				t.Errorf("telegramQuotedAuthor() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The role tells the agent whether it is looking at its own earlier message or
+// someone else's — which changes what a reply to it means.
+func TestTelegramQuotedRole(t *testing.T) {
+	c := &TelegramChannel{}
+
+	tests := []struct {
+		name string
+		msg  *telego.Message
+		want string
+	}{
+		{"human", &telego.Message{From: &telego.User{IsBot: false}}, "user"},
+		{"another bot", &telego.Message{From: &telego.User{IsBot: true, Username: "other"}}, "bot"},
+		{"channel post", &telego.Message{SenderChat: &telego.Chat{ID: 1}}, "chat"},
+		{"unknown", &telego.Message{}, "unknown"},
+		{"nil", nil, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.telegramQuotedRole(tc.msg); got != tc.want {
+				t.Errorf("telegramQuotedRole() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrependTelegramQuotedReply(t *testing.T) {
+	c := &TelegramChannel{}
+	quoted := &telego.Message{
+		Text: "should we deploy?",
+		From: &telego.User{Username: "alice"},
+	}
+
+	t.Run("prepends labelled context", func(t *testing.T) {
+		got := c.prependTelegramQuotedReply("yes", quoted)
+		for _, want := range []string{"quoted", "alice", "should we deploy?", "yes"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("got %q, want it to contain %q", got, want)
+			}
+		}
+		// The reply must come after the quote, or the agent reads the answer
+		// before the question.
+		if strings.Index(got, "should we deploy?") > strings.Index(got, "yes") {
+			t.Errorf("quote appears after the reply: %q", got)
+		}
+	})
+
+	t.Run("reply with no text still carries the quote", func(t *testing.T) {
+		got := c.prependTelegramQuotedReply("", quoted)
+		if !strings.Contains(got, "should we deploy?") {
+			t.Errorf("got %q, want the quoted text", got)
+		}
+	})
+
+	t.Run("empty quote leaves content untouched", func(t *testing.T) {
+		if got := c.prependTelegramQuotedReply("hello", &telego.Message{}); got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+}
+
+// Audio in a quoted message is attached so the agent can hear what is being
+// referred to, rather than only being told that a voice note exists.
+func TestQuotedTelegramMediaRefs_ResolvesAudio(t *testing.T) {
+	var asked []string
+	resolve := func(fileID, ext, filename string) string {
+		asked = append(asked, fileID+ext)
+		return "ref://" + filename
+	}
+
+	refs := quotedTelegramMediaRefs(&telego.Message{
+		Voice: &telego.Voice{FileID: "v"},
+		Audio: &telego.Audio{FileID: "a"},
+	}, resolve)
+
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2: %v", len(refs), refs)
+	}
+	if refs[0] != "ref://voice.ogg" || refs[1] != "ref://audio.mp3" {
+		t.Errorf("refs = %v, want voice then audio", refs)
+	}
+	if len(asked) != 2 || asked[0] != "v.ogg" || asked[1] != "a.mp3" {
+		t.Errorf("resolver saw %v, want v.ogg then a.mp3", asked)
+	}
+
+	if got := quotedTelegramMediaRefs(nil, resolve); got != nil {
+		t.Errorf("nil message returned %v", got)
+	}
+	if got := quotedTelegramMediaRefs(&telego.Message{}, nil); got != nil {
+		t.Errorf("nil resolver returned %v", got)
+	}
+	// A resolver that fails must contribute nothing rather than an empty ref.
+	empty := quotedTelegramMediaRefs(
+		&telego.Message{Voice: &telego.Voice{FileID: "v"}},
+		func(string, string, string) string { return "" },
+	)
+	if len(empty) != 0 {
+		t.Errorf("failed resolution produced %v, want nothing", empty)
+	}
+}

--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -708,6 +708,26 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		}
 	}
 
+	// Prepend the quoted message before the empty check: a bare "yes" replying
+	// to something is meaningful, and would otherwise be dropped here as empty.
+	if message.ReplyToMessage != nil {
+		quotedMedia := quotedTelegramMediaRefs(
+			message.ReplyToMessage,
+			func(fileID, ext, filename string) string {
+				localPath := c.downloadFile(ctx, fileID, ext)
+				if localPath == "" {
+					return ""
+				}
+				return storeMedia(localPath, filename)
+			},
+		)
+		if len(quotedMedia) > 0 {
+			// Quoted media leads: it is the thing being referred to.
+			mediaPaths = append(quotedMedia, mediaPaths...)
+		}
+		content = c.prependTelegramQuotedReply(content, message.ReplyToMessage)
+	}
+
 	if content == "" && len(mediaPaths) == 0 {
 		return nil
 	}
@@ -761,6 +781,10 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		"username":   user.Username,
 		"first_name": user.FirstName,
 		"is_group":   fmt.Sprintf("%t", message.Chat.Type != "private"),
+	}
+
+	if message.ReplyToMessage != nil {
+		metadata["reply_to_message_id"] = fmt.Sprintf("%d", message.ReplyToMessage.MessageID)
 	}
 
 	// Set parent_peer metadata for per-topic agent binding.
@@ -1192,4 +1216,128 @@ func (c *TelegramChannel) stripBotMention(content string) string {
 	re := regexp.MustCompile(`(?i)@` + regexp.QuoteMeta(botUsername))
 	content = re.ReplaceAllString(content, "")
 	return strings.TrimSpace(content)
+}
+
+// --- Quoted replies -------------------------------------------------------
+//
+// A Telegram reply carries the message it answers, but without this the agent
+// saw only the new text. "yes, do that" with no idea what "that" was is not a
+// prompt anything can act on. The quoted message is prepended as labelled
+// context, and any audio it carried is attached so the agent can hear what is
+// being referred to rather than only being told it exists.
+
+func (c *TelegramChannel) prependTelegramQuotedReply(content string, reply *telego.Message) string {
+	quoted := strings.TrimSpace(telegramQuotedContent(reply))
+	if quoted == "" {
+		return content
+	}
+
+	author := telegramQuotedAuthor(reply)
+	role := c.telegramQuotedRole(reply)
+	if strings.TrimSpace(content) == "" {
+		return fmt.Sprintf("[quoted %s message from %s]: %s", role, author, quoted)
+	}
+	return fmt.Sprintf("[quoted %s message from %s]: %s\n\n%s", role, author, quoted, content)
+}
+
+func (c *TelegramChannel) telegramQuotedRole(message *telego.Message) string {
+	if message == nil {
+		return "unknown"
+	}
+
+	if message.From != nil {
+		if !message.From.IsBot {
+			return "user"
+		}
+		if c.isOwnBotUser(message.From) {
+			return "assistant"
+		}
+		return "bot"
+	}
+
+	if message.SenderChat != nil {
+		return "chat"
+	}
+
+	return "unknown"
+}
+
+func (c *TelegramChannel) isOwnBotUser(user *telego.User) bool {
+	if c == nil || c.bot == nil || user == nil || !user.IsBot {
+		return false
+	}
+
+	if botID := c.bot.ID(); botID != 0 && user.ID == botID {
+		return true
+	}
+
+	botUsername := strings.TrimPrefix(strings.TrimSpace(c.bot.Username()), "@")
+	if botUsername == "" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimPrefix(strings.TrimSpace(user.Username), "@"), botUsername)
+}
+
+func telegramQuotedAuthor(message *telego.Message) string {
+	if message == nil || message.From == nil {
+		return "unknown"
+	}
+	if username := strings.TrimSpace(message.From.Username); username != "" {
+		return username
+	}
+	if firstName := strings.TrimSpace(message.From.FirstName); firstName != "" {
+		return firstName
+	}
+	return "unknown"
+}
+
+func telegramQuotedContent(message *telego.Message) string {
+	if message == nil {
+		return ""
+	}
+
+	var parts []string
+	if text := strings.TrimSpace(message.Text); text != "" {
+		parts = append(parts, text)
+	}
+	if caption := strings.TrimSpace(message.Caption); caption != "" {
+		parts = append(parts, caption)
+	}
+	switch {
+	case len(message.Photo) > 0:
+		parts = append(parts, "[image: photo]")
+	}
+	switch {
+	case message.Voice != nil:
+		parts = append(parts, "[voice]")
+	case message.Audio != nil:
+		parts = append(parts, "[audio]")
+	}
+	if message.Document != nil {
+		parts = append(parts, "[file]")
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+func quotedTelegramMediaRefs(
+	message *telego.Message,
+	resolve func(fileID, ext, filename string) string,
+) []string {
+	if message == nil || resolve == nil {
+		return nil
+	}
+
+	var refs []string
+	if message.Voice != nil {
+		if ref := resolve(message.Voice.FileID, ".ogg", "voice.ogg"); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	if message.Audio != nil {
+		if ref := resolve(message.Audio.FileID, ".mp3", "audio.mp3"); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }


### PR DESCRIPTION
Ports upstream picoclaw `2d855620`. Tier C.

## Why

A Telegram reply carries the message it answers, but the agent saw only the new text. **"yes, do
that" arrived with no indication of what "that" was** — not something a model can act on.

The quoted message is now prepended as labelled context (role, author, content, with markers for
media it carried), and any audio in it is attached so the agent can **hear** what is being referred
to rather than only being told a voice note exists.

## Two placement decisions

**The prepend happens before the empty-content check.** A bare "yes" replying to something is
meaningful; without this it would be dropped there as an empty message.

**Quoted media leads the attachment list**, since it is the thing being referred to rather than
something the new message added.

## ⚠️ A coverage gap I want to be explicit about

**Mutation testing found a hole in my own tests.**

| Mutation | Caught? |
|---|---|
| Quote placed *after* the reply instead of before | ✅ `quote appears after the reply: "yes\n\n[quoted user message from alice]…"` |
| **The call site removed from `handleMessage` entirely** | ❌ **every test still passed** |

The tests exercise the helpers directly, so deleting the wiring in `handleMessage` breaks the
feature without failing anything. `handleMessage` needs a `telego` bot to construct, and there is no
existing fake for it in this package, so I did not build one for this port.

What that means concretely: **the helpers are well covered, the integration is not.** If someone
later refactors `handleMessage` and drops the block, CI will stay green. I would rather say that
than present five green tests as if they covered the feature.

## How it was tested

| Test | Property |
|---|---|
| `TestTelegramQuotedContent_DescribesWhatWasQuoted` | text, caption, photo, voice, audio, document, and caption-alongside-media |
| `TestTelegramQuotedAuthor_PrefersUsername` | username, then first name, then `unknown` |
| `TestTelegramQuotedRole` | distinguishes a human, another bot, a channel post — the agent needs to know if it is reading its own earlier message |
| `TestPrependTelegramQuotedReply` | ordering, empty reply text, empty quote |
| `TestQuotedTelegramMediaRefs_ResolvesAudio` | voice before audio, nil inputs, and a failed resolution contributing nothing |

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 | **0 issues** |

## Known limitations

- **The `handleMessage` integration is untested** — see above. That is the main weakness of this PR.
- **`isOwnBotUser` is only exercised indirectly.** Its `c.bot == nil` guard means the "assistant"
  role never resolves in tests, so a reply to our own message is not covered end to end.
- Only voice and audio are attached from a quoted message. Photos and documents are described in the
  text but not re-attached, matching upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN