### PR TITLE
feat(config): record a schema version in config.json

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,6 +104,12 @@ func (f *FlexibleStringSlice) UnmarshalText(text []byte) error {
 }
 
 type Config struct {
+	// Version records the schema this config was written against. Absent means
+	// 0 — a config predating the field — which is treated as the current shape,
+	// since version 1 introduced no changes. yaml:"-" keeps it out of
+	// .security.yml, which holds credentials rather than schema metadata.
+	Version int `json:"version,omitempty" yaml:"-"`
+
 	Agents      AgentsConfig      `json:"agents"                yaml:"-"`
 	Bindings    []AgentBinding    `json:"bindings,omitempty"    yaml:"-"`
 	Session     SessionConfig     `json:"session,omitempty"     yaml:"-"`
@@ -1304,6 +1310,12 @@ func LoadConfig(path string) (*Config, error) {
 	// file:// and enc:// references relative to the config directory.
 	updateResolver(path)
 
+	// Take the version from the file itself. Unmarshalling onto DefaultConfig
+	// leaves the default's version in place when the key is absent, which would
+	// make a config predating the field indistinguishable from a current one —
+	// the exact distinction this field exists to record.
+	cfg.Version = onDiskConfigVersion(data)
+
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}
@@ -1319,7 +1331,17 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
-	// Migrate legacy channel config fields to new unified structures
+	// Refuse a config written by a newer build before touching anything else.
+	// Loading it would silently drop fields this build does not know, and the
+	// next save would write that loss back to disk.
+	if err := checkConfigVersion(cfg.Version); err != nil {
+		return nil, err
+	}
+
+	// Migrate legacy channel config fields to new unified structures.
+	// Still unconditional: these are idempotent and predate versioning, and
+	// gating them on version carries user-data risk for no gain until there is
+	// a second version to gate against.
 	cfg.migrateChannelConfigs()
 
 	// Auto-migrate: if only legacy providers config exists, convert to model_list
@@ -1368,6 +1390,12 @@ func LoadConfigSkipSecurity(path string) (*Config, error) {
 
 	updateResolver(path)
 
+	// Take the version from the file itself. Unmarshalling onto DefaultConfig
+	// leaves the default's version in place when the key is absent, which would
+	// make a config predating the field indistinguishable from a current one —
+	// the exact distinction this field exists to record.
+	cfg.Version = onDiskConfigVersion(data)
+
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}
@@ -1412,6 +1440,9 @@ func SaveConfig(path string, cfg *Config) error {
 	if err := saveSecurityConfig(securityPath(path), cfg); err != nil {
 		return err
 	}
+
+	// Record the schema this file was written against.
+	applyConfigVersion(cfg)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -29,6 +29,8 @@ func DefaultConfig() *Config {
 	workspacePath := filepath.Join(homePath, "workspace")
 
 	return &Config{
+		// A fresh install is current, so it never looks like a legacy config.
+		Version: CurrentConfigVersion,
 		Agents: AgentsConfig{
 			Defaults: AgentDefaults{
 				Workspace:                  workspacePath,

--- a/pkg/config/schema_version.go
+++ b/pkg/config/schema_version.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CurrentConfigVersion is the schema version this build writes and understands.
+//
+// Version 1 is the shape the config already had when versioning was introduced,
+// so the 0 → 1 transition migrates nothing. The point of the field is future
+// changes: today the migrations in this package infer what needs converting by
+// inspecting the data (see migrateChannelConfigs and the providers → model_list
+// conversion), which means they run on every load and have to keep guessing.
+// A recorded version lets a later migration know what it is reading instead.
+const CurrentConfigVersion = 1
+
+// legacyConfigVersion is what an absent "version" key means: a config written
+// before the field existed.
+const legacyConfigVersion = 0
+
+// ErrConfigTooNew reports a config written by a newer build than this one.
+var ErrConfigTooNew = fmt.Errorf("config was written by a newer version of khunquant")
+
+// checkConfigVersion decides whether a loaded config can be used.
+//
+// A config from the future is refused rather than loaded. The alternative —
+// loading it, silently dropping the fields this build does not know, and
+// writing it back at our own version — destroys settings a newer build wrote,
+// and does so invisibly. Refusing is recoverable; a silent downgrade is not.
+func checkConfigVersion(version int) error {
+	if version > CurrentConfigVersion {
+		return fmt.Errorf("%w (config version %d, this build understands %d)",
+			ErrConfigTooNew, version, CurrentConfigVersion)
+	}
+	return nil
+}
+
+// applyConfigVersion stamps the current version onto a config being saved.
+//
+// Deliberately separate from the migration functions: this records what shape
+// was written, it does not change the shape. The existing migrations still run
+// unconditionally on load, exactly as before — gating those on version is a
+// change with real user-data risk and buys nothing until there is a second
+// version to gate against.
+func applyConfigVersion(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Version = CurrentConfigVersion
+}
+
+// onDiskConfigVersion reports the version recorded in raw config bytes, or
+// legacyConfigVersion when the key is absent or the bytes do not parse.
+//
+// Read separately from the main unmarshal because that overlays onto
+// DefaultConfig, whose version is already current: an absent key would leave
+// the default in place and a legacy config would look like a current one.
+func onDiskConfigVersion(data []byte) int {
+	var probe struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return legacyConfigVersion
+	}
+	return probe.Version
+}

--- a/pkg/config/schema_version_test.go
+++ b/pkg/config/schema_version_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The property that matters is round-trip safety on a config written before the
+// version field existed. Every installed config is one of those.
+
+func writeRawConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// A config with no "version" key must load cleanly and keep its settings.
+func TestLoadConfig_AcceptsConfigWithoutVersion(t *testing.T) {
+	path := writeRawConfig(t, `{
+	  "agents": {"defaults": {"model_name": "claude-sonnet-5", "max_tokens": 4096}},
+	  "gateway": {"host": "127.0.0.1", "port": 18790}
+	}`)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.Version != legacyConfigVersion {
+		t.Errorf("Version = %d, want %d for a config predating the field", cfg.Version, legacyConfigVersion)
+	}
+	if cfg.Agents.Defaults.ModelName != "claude-sonnet-5" {
+		t.Errorf("ModelName = %q, want it preserved", cfg.Agents.Defaults.ModelName)
+	}
+	if cfg.Gateway.Port != 18790 {
+		t.Errorf("Gateway.Port = %d, want it preserved", cfg.Gateway.Port)
+	}
+}
+
+// Saving stamps the version, and reloading is stable.
+func TestSaveConfig_StampsVersionAndRoundTrips(t *testing.T) {
+	path := writeRawConfig(t, `{"agents": {"defaults": {"model_name": "claude-sonnet-5"}}}`)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var onDisk map[string]any
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("parse saved config: %v", err)
+	}
+	got, ok := onDisk["version"]
+	if !ok {
+		t.Fatal(`saved config has no "version" key`)
+	}
+	if int(got.(float64)) != CurrentConfigVersion {
+		t.Errorf("saved version = %v, want %d", got, CurrentConfigVersion)
+	}
+
+	reloaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("reload error = %v", err)
+	}
+	if reloaded.Version != CurrentConfigVersion {
+		t.Errorf("reloaded Version = %d, want %d", reloaded.Version, CurrentConfigVersion)
+	}
+	if reloaded.Agents.Defaults.ModelName != "claude-sonnet-5" {
+		t.Errorf("ModelName = %q, want it preserved across the round trip", reloaded.Agents.Defaults.ModelName)
+	}
+}
+
+// A config from a newer build must be refused rather than loaded, downgraded
+// and written back — that would strip settings the newer build wrote, silently.
+func TestLoadConfig_RefusesConfigFromNewerBuild(t *testing.T) {
+	path := writeRawConfig(t, `{
+	  "version": 99,
+	  "agents": {"defaults": {"model_name": "some-future-model"}}
+	}`)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("a config from a newer build was loaded; its unknown fields would be dropped on the next save")
+	}
+	if !errors.Is(err, ErrConfigTooNew) {
+		t.Errorf("error = %v, want it to wrap ErrConfigTooNew", err)
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error = %q, want it to name the version found", err.Error())
+	}
+
+	// The file must be left alone.
+	raw, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if !strings.Contains(string(raw), "some-future-model") {
+		t.Error("the refused config was modified on disk")
+	}
+}
+
+func TestCheckConfigVersion(t *testing.T) {
+	for _, v := range []int{legacyConfigVersion, CurrentConfigVersion} {
+		if err := checkConfigVersion(v); err != nil {
+			t.Errorf("checkConfigVersion(%d) = %v, want nil", v, err)
+		}
+	}
+	if err := checkConfigVersion(CurrentConfigVersion + 1); err == nil {
+		t.Error("a future version was accepted")
+	}
+}
+
+// A fresh install must not look like a legacy config.
+func TestDefaultConfig_IsCurrentSchemaVersion(t *testing.T) {
+	if got := DefaultConfig().Version; got != CurrentConfigVersion {
+		t.Errorf("DefaultConfig().Version = %d, want %d", got, CurrentConfigVersion)
+	}
+}
+
+// The schema version is metadata, not a credential, and must not reach the
+// security sidecar.
+func TestSchemaVersion_IsNotWrittenToSecurityFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := SaveConfig(path, DefaultConfig()); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(securityPath(path))
+	if err != nil {
+		t.Fatalf("read security file: %v", err)
+	}
+	if strings.Contains(string(raw), "version") {
+		t.Errorf(".security.yml contains a version key:\n%s", raw)
+	}
+}


### PR DESCRIPTION
**D4.** Adopts the versioning substrate from upstream picoclaw `1c123e01` — **without** its
`config_old.go`, and at a fraction of its 128 files.

## Why not a straight port

`config_old.go` is a snapshot of **upstream's** field set at that moment. Copying it would declare
that our users once had a config shape they never had, and any future migration reading it would
mishandle `SecureString`, `exchanges`, `deltaneutral` and the broker configs. **The mechanism ports;
the snapshot cannot.**

## What lands

- **`Config.Version`**, absent meaning `0` — a config predating the field.
- **The version is read from the file**, not taken after unmarshal. Unmarshalling overlays
  `DefaultConfig`, whose version is current, so an absent key would leave the default in place and a
  legacy config would be **indistinguishable from a current one** — the exact distinction the field
  exists to record. I found this because the round-trip test failed.
- **A config from a newer build is refused.** Loading it would drop fields this build does not know
  and write that loss back on the next save. Refusing is recoverable; a silent downgrade is not.
  Upstream's commit does not answer this — it is a choice.
- `SaveConfig` stamps the current version; `DefaultConfig` starts current, so a fresh install never
  looks legacy.

## This changes no behaviour

**Version 1 is the shape the config already had**, so the 0 → 1 transition migrates nothing. The
existing migrations — `migrateChannelConfigs` and the providers → `model_list` conversion — still run
unconditionally, exactly as before.

Gating those on version carries real user-data risk and buys nothing until there is a second version
to gate against. That is a separate change, deliberately not made here.

`yaml:"-"` keeps the field out of `.security.yml`, which holds credentials rather than schema
metadata — asserted by a test.

## How it was tested

| Test | Property |
|---|---|
| `TestLoadConfig_AcceptsConfigWithoutVersion` | a config predating the field loads clean, reports version 0, keeps its settings |
| `TestSaveConfig_StampsVersionAndRoundTrips` | save writes the version, reload is stable, settings survive |
| `TestLoadConfig_RefusesConfigFromNewerBuild` | refused, error names the version found, **and the file is left untouched on disk** |
| `TestSchemaVersion_IsNotWrittenToSecurityFile` | the version does not reach `.security.yml` |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| Save stops stamping | `saved config has no "version" key` |
| Future version accepted | `a config from a newer build was loaded…` |
| On-disk version read removed | `Version = 1, want 0 for a config predating the field` |

| Check | Result |
|---|---|
| `go test ./...` | no failures |
| `golangci-lint` v2.10.1 | **0 issues** |

## Known limitations

- **No migration framework beyond the version field.** There is no registry of version→version
  migrations, because there is nothing to migrate yet. The next schema change adds both the bump and
  its migration; this PR only makes that possible.
- **The ~12 downstream migration commits are still unported.** This unblocks them; it does not
  deliver them, and each still needs judging against our diverged config on its own merits.
- **The refusal is absolute.** A user who downgrades the binary after saving a newer config must
  edit `version` by hand. That is deliberate — the alternative destroys settings — but it is a rough
  edge with no guidance in the error beyond the two version numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMiMj9dwkDmA1LF3Dk8uN